### PR TITLE
feat: site operator detail pages

### DIFF
--- a/site/scripts/extract-data.py
+++ b/site/scripts/extract-data.py
@@ -14,7 +14,7 @@ AI_THRESHOLD = 10.0
 
 def parse_hardware_yaml(path: Path) -> dict:
     text = path.read_text()
-    result = {"name": "", "p_peak": {}, "b_peak_hbm": 0}
+    result = {"name": "", "p_peak": {}, "b_peak_hbm": 0, "launch_overhead_us": None}
     section = ""
     for line in text.splitlines():
         stripped = line.strip()
@@ -22,6 +22,13 @@ def parse_hardware_yaml(path: Path) -> dict:
             continue
         if "name:" in line and "hardware" not in line.lower().split("name")[0]:
             result["name"] = stripped.split("name:")[1].strip().strip('"').strip("'")
+        if stripped.startswith("launch_overhead_s") and ":" in stripped:
+            val = stripped.split(":")[1].strip().split("#")[0].strip()
+            if val and val != "null":
+                try:
+                    result["launch_overhead_us"] = float(val) * 1e6
+                except ValueError:
+                    pass
         if stripped.startswith("p_peak"):
             section = "p_peak"
         elif stripped.startswith("b_peak"):
@@ -51,10 +58,13 @@ def main():
     for yaml_file in sorted(HARDWARE_DIR.glob("*.yaml")):
         hw = parse_hardware_yaml(yaml_file)
         if hw["name"]:
-            hardware_configs[hw["name"]] = {
+            cfg: dict = {
                 "p_peak": hw["p_peak"],
                 "b_peak_hbm": hw["b_peak_hbm"],
             }
+            if hw["launch_overhead_us"] is not None:
+                cfg["launch_overhead_us"] = hw["launch_overhead_us"]
+            hardware_configs[hw["name"]] = cfg
 
     operators = []
     total_shapes = 0
@@ -173,6 +183,34 @@ def main():
             prod_shapes[sku] = shapes_us
         total_prod_perf_shapes += len(measured_sids)
 
+        # Source code for detail pages
+        ref_path = op_dir / "reference.py"
+        inp_path = op_dir / "input.py"
+        reference_code = ref_path.read_text() if ref_path.exists() else ""
+        input_code = inp_path.read_text() if inp_path.exists() else ""
+
+        # Merged per-shape details (kwargs + roofline + prod)
+        shape_details = {}
+        for sid, skw in shapes.items():
+            entry: dict = {}
+            shape_meta = metadata_shapes.get(sid, {})
+            if isinstance(shape_meta, dict):
+                entry["description"] = shape_meta.get("description", "")
+            entry["init_kwargs"] = skw.get("init_kwargs", {})
+            entry["input_kwargs"] = skw.get("input_kwargs", {})
+            rs = roofline_shapes.get(sid)
+            if rs:
+                entry["W_flops"] = rs["W_flops"]
+                entry["Q_bytes"] = rs["Q_bytes"]
+                entry["ai"] = rs["ai"]
+                entry["SOL_time_ms"] = rs["SOL_time_ms"]
+            prod_us_by_sku = {}
+            for sku, sku_shapes in prod_shapes.items():
+                if sid in sku_shapes:
+                    prod_us_by_sku[sku] = sku_shapes[sid]
+            entry["prod_us"] = prod_us_by_sku if prod_us_by_sku else None
+            shape_details[sid] = entry
+
         operators.append({
             "name": op_dir.name,
             "id": metadata.get("id", ""),
@@ -187,6 +225,9 @@ def main():
             "roofline_shapes": roofline_shapes,
             "production_perf": prod_summary,
             "production_shapes": prod_shapes,
+            "reference_code": reference_code,
+            "input_code": input_code,
+            "shape_details": shape_details,
         })
 
     operators.sort(key=lambda x: x["importance"], reverse=True)
@@ -195,11 +236,14 @@ def main():
     hw_summary = {}
     for name, cfg in hardware_configs.items():
         p = cfg["p_peak"]
-        hw_summary[name] = {
+        spec: dict = {
             "bf16_tflops": round(p.get("bf16_tc", 0) / 1e12, 1),
             "fp8_tflops": round(p.get("fp8_e4m3_tc", 0) / 1e12, 1) if p.get("fp8_e4m3_tc") else None,
             "bw_tb_s": round(cfg["b_peak_hbm"] / 1e12, 1),
         }
+        if cfg.get("launch_overhead_us") is not None:
+            spec["launch_overhead_us"] = round(cfg["launch_overhead_us"], 2)
+        hw_summary[name] = spec
 
     result = {
         "stats": {

--- a/site/src/components/OperatorCatalog.astro
+++ b/site/src/components/OperatorCatalog.astro
@@ -6,6 +6,8 @@ const dtypes = [...new Set(operators.map((o: any) => o.dtype))].sort();
 const frameworks = [...new Set(operators.map((o: any) => o.framework))].sort();
 const phases = [...new Set(operators.map((o: any) => o.phase))].sort();
 
+const prodSku = 'XPU-A';
+
 function regimeBadge(regime: string) {
   if (regime === 'compute-bound') return 'bg-red-900/40 text-red-300 border-red-800';
   if (regime === 'memory-bound') return 'bg-blue-900/40 text-blue-300 border-blue-800';
@@ -16,6 +18,8 @@ function regimeLabel(regime: string) {
   if (regime === 'memory-bound') return 'memory';
   return 'index';
 }
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
 <div class="page-section">
@@ -38,29 +42,32 @@ function regimeLabel(regime: string) {
 
     <div class="card overflow-hidden p-0">
       <div class="overflow-x-auto">
-        <table class="w-full text-sm" id="operator-table">
+        <table class="w-full text-xs" id="operator-table">
           <thead>
             <tr class="border-b border-gray-800 bg-gray-900/50">
-              <th class="text-left py-3 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-sort="name">
-                <span data-i18n="operators.table.name">Operator</span> <span class="sort-arrow text-gray-600">&#x25B4;&#x25BE;</span>
+              <th class="text-left py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-sort="id">
+                ID <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-left py-3 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-sort="dtype">
-                <span data-i18n="operators.table.dtype">dtype</span>
+              <th class="text-left py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-sort="name">
+                Operator <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-left py-3 px-3 text-gray-400 font-medium hidden md:table-cell">
-                Regime
+              <th class="text-left py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-sort="dtype">
+                dtype <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-left py-3 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none hidden sm:table-cell" data-sort="framework">
-                <span data-i18n="operators.table.framework">Framework</span>
+              <th class="text-left py-2.5 px-3 text-gray-400 font-medium hidden md:table-cell cursor-pointer hover:text-white select-none" data-sort="regime">
+                Regime <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-right py-3 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-sort="shapes">
-                <span data-i18n="operators.table.shapes">Shapes</span>
+              <th class="text-left py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none hidden sm:table-cell" data-sort="framework">
+                Framework <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-right py-3 px-3 text-gray-400 font-medium hidden lg:table-cell">
-                T<sub>Prod</sub> <span class="text-gray-600 font-normal">(XPU-A)</span>
+              <th class="text-right py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-sort="shapes">
+                Shapes <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-right py-3 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-sort="importance">
-                <span data-i18n="operators.table.importance">Importance</span>
+              <th class="text-right py-2.5 px-3 text-gray-400 font-medium hidden lg:table-cell cursor-pointer hover:text-white select-none" data-sort="tprod">
+                T<sub>Prod</sub> <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
+              </th>
+              <th class="text-right py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-sort="importance">
+                Importance <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
             </tr>
           </thead>
@@ -68,11 +75,11 @@ function regimeLabel(regime: string) {
             {operators.map((op: any) => (
               <tr class="border-b border-gray-800/30 hover:bg-gray-800/30 transition-colors"
                   data-dtype={op.dtype} data-phase={op.phase} data-framework={op.framework}>
-                <td class="py-2.5 px-3">
-                  <code class="text-white font-mono text-xs">{op.name}</code>
-                  <div class="text-gray-600 text-xs mt-0.5 font-mono">{op.id}</div>
+                <td class="py-2 px-3 text-gray-500 font-mono">{op.id.replace('atrex_', '')}</td>
+                <td class="py-2 px-3">
+                  <a href={`${base}/operator/${op.id}`} class="hover:underline"><code class="text-white font-mono">{op.name}</code></a>
                 </td>
-                <td class="py-2.5 px-3">
+                <td class="py-2 px-3">
                   <span class={`badge ${
                     op.dtype === 'bf16' ? 'badge-bf16' :
                     op.dtype === 'fp16' ? 'badge-fp16' :
@@ -81,30 +88,30 @@ function regimeLabel(regime: string) {
                     'badge-int32'
                   }`}>{op.dtype}</span>
                 </td>
-                <td class="py-2.5 px-3 hidden md:table-cell">
+                <td class="py-2 px-3 hidden md:table-cell">
                   {op.roofline ? (
                     <span class={`badge text-xs ${regimeBadge(op.roofline.regime)}`}>
                       {regimeLabel(op.roofline.regime)}
                     </span>
                   ) : <span class="text-gray-600">—</span>}
                 </td>
-                <td class="py-2.5 px-3 text-gray-400 text-xs hidden sm:table-cell">{op.framework}</td>
-                <td class="py-2.5 px-3 text-right text-gray-300">{op.shapes}</td>
-                <td class="py-2.5 px-3 text-right hidden lg:table-cell">
-                  {op.production_perf?.['XPU-A'] ? (
-                    <span class="text-gray-300 font-mono text-xs">
-                      {op.production_perf['XPU-A'].median_us >= 1000
-                        ? (op.production_perf['XPU-A'].median_us / 1000).toFixed(1) + ' ms'
-                        : op.production_perf['XPU-A'].median_us.toFixed(0) + ' us'}
+                <td class="py-2 px-3 text-gray-400 hidden sm:table-cell">{op.framework}</td>
+                <td class="py-2 px-3 text-right text-gray-300">{op.shapes}</td>
+                <td class="py-2 px-3 text-right hidden lg:table-cell">
+                  {op.production_perf?.[prodSku] ? (
+                    <span class="text-gray-300 font-mono">
+                      {op.production_perf[prodSku].median_us >= 1000
+                        ? (op.production_perf[prodSku].median_us / 1000).toFixed(1) + ' ms'
+                        : op.production_perf[prodSku].median_us.toFixed(0) + ' us'}
                     </span>
                   ) : <span class="text-gray-600">—</span>}
                 </td>
-                <td class="py-2.5 px-3 text-right">
+                <td class="py-2 px-3 text-right">
                   <div class="flex items-center justify-end gap-2">
                     <div class="w-16 h-1.5 bg-gray-800 rounded-full overflow-hidden hidden sm:block">
                       <div class="h-full bg-brand-500 rounded-full" style={`width: ${Math.min(op.importance / 0.4 * 100, 100)}%`}></div>
                     </div>
-                    <span class="text-gray-300 font-mono text-xs w-14 text-right">{(op.importance * 100).toFixed(1)}%</span>
+                    <span class="text-gray-300 font-mono w-14 text-right">{(op.importance * 100).toFixed(1)}%</span>
                   </div>
                 </td>
               </tr>
@@ -142,14 +149,34 @@ function regimeLabel(regime: string) {
   [filterDtype, filterPhase, filterFramework].forEach(el => el.addEventListener('change', applyFilters));
 
   let currentSort = { key: '', asc: true };
-  document.querySelectorAll('[data-sort]').forEach(th => {
+  const sortableThs = document.querySelectorAll('#operator-table [data-sort]');
+
+  function updateSortArrows() {
+    sortableThs.forEach(th => {
+      const arrow = th.querySelector('.sort-arrow');
+      if (!arrow) return;
+      const key = (th as HTMLElement).dataset.sort!;
+      if (key === currentSort.key) {
+        arrow.innerHTML = currentSort.asc ? '&#x25B4;' : '&#x25BE;';
+        arrow.classList.remove('text-gray-600');
+        arrow.classList.add('text-white');
+      } else {
+        arrow.innerHTML = '&#x25B4;&#x25BE;';
+        arrow.classList.remove('text-white');
+        arrow.classList.add('text-gray-600');
+      }
+    });
+  }
+
+  sortableThs.forEach(th => {
     th.addEventListener('click', () => {
       const key = (th as HTMLElement).dataset.sort!;
       if (currentSort.key === key) currentSort.asc = !currentSort.asc;
       else currentSort = { key, asc: true };
+      updateSortArrows();
       const rows = Array.from(tbody.querySelectorAll('tr'));
       rows.sort((a, b) => {
-        const colMap: Record<string, number> = { name: 0, dtype: 1, framework: 3, shapes: 4, importance: 6 };
+        const colMap: Record<string, number> = { id: 0, name: 1, dtype: 2, regime: 3, framework: 4, shapes: 5, tprod: 6, importance: 7 };
         const colIdx = colMap[key] ?? 0;
         const cellA = a.querySelectorAll('td')[colIdx];
         const cellB = b.querySelectorAll('td')[colIdx];
@@ -158,6 +185,14 @@ function regimeLabel(regime: string) {
         let vb: any = cellB.textContent?.trim() || '';
         if (key === 'shapes') { va = parseInt(va); vb = parseInt(vb); }
         else if (key === 'importance') { va = parseFloat(va); vb = parseFloat(vb); }
+        else if (key === 'tprod') {
+          const parseTime = (s: string) => {
+            if (s === '—') return -1;
+            if (s.endsWith('ms')) return parseFloat(s) * 1000;
+            return parseFloat(s);
+          };
+          va = parseTime(va); vb = parseTime(vb);
+        }
         if (va < vb) return currentSort.asc ? -1 : 1;
         if (va > vb) return currentSort.asc ? 1 : -1;
         return 0;
@@ -165,4 +200,8 @@ function regimeLabel(regime: string) {
       rows.forEach(r => tbody.appendChild(r));
     });
   });
+
+  // Default sort by ID
+  const idTh = document.querySelector('#operator-table [data-sort="id"]') as HTMLElement;
+  if (idTh) idTh.click();
 </script>

--- a/site/src/components/RooflineDetail.astro
+++ b/site/src/components/RooflineDetail.astro
@@ -129,12 +129,16 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
                   </td>
                   {hardware.map((hw: string) => {
                     const sol_us = rs.SOL_time_ms?.[hw];
+                    const floor = (hardware_specs as any)[hw]?.launch_overhead_us;
+                    const isClamped = floor != null && sol_us != null && floor + 0.01 >= sol_us;
                     return (
                       <td class="py-2 px-3 text-right font-mono text-gray-300">
                         {sol_us != null
-                          ? sol_us >= 1000
-                            ? (sol_us / 1000).toFixed(2) + ' ms'
-                            : sol_us.toFixed(2) + ' us'
+                          ? isClamped
+                            ? '< ' + floor.toFixed(1) + ' us'
+                            : sol_us >= 1000
+                              ? (sol_us / 1000).toFixed(2) + ' ms'
+                              : sol_us.toFixed(2) + ' us'
                           : <span class="text-gray-600">—</span>}
                       </td>
                     );

--- a/site/src/components/RooflineDetail.astro
+++ b/site/src/components/RooflineDetail.astro
@@ -7,18 +7,16 @@ const hwShort: Record<string, string> = {
   'H20': 'H20',
 };
 
-// Available prod hardware (extensible)
 const prodHardware = ['XPU-A', 'H20'];
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
 <div class="page-section">
   <div class="page-container">
 
-    <!-- ── Hardware specs ── -->
-    <h2 class="section-heading !mt-0">
-      <span >Hardware Platforms</span>
-      
-    </h2>
+    <!-- Hardware specs -->
+    <h2 class="section-heading !mt-0">Hardware Platforms</h2>
     <div class="grid sm:grid-cols-3 gap-4 mb-12">
       {hardware.map((hw: string) => {
         const spec = (hardware_specs as any)[hw];
@@ -52,14 +50,12 @@ const prodHardware = ['XPU-A', 'H20'];
       })}
     </div>
 
-    <!-- ── Per-operator roofline table ── -->
-    <h2 class="section-heading">
-      <span >Roofline by Operator &times; Hardware</span>
-      
-    </h2>
-    <p lang="en" class="text-gray-400 text-sm mb-2">
+    <!-- Per-operator roofline table -->
+    <h2 class="section-heading">Roofline by Operator &times; Hardware</h2>
+    <p class="text-gray-400 text-sm mb-2">
       T<sub>SOL</sub> is the theoretical Speed-of-Light lower bound: max(W/P<sub>peak</sub>, Q/B<sub>peak</sub>). T<sub>Prod</sub> is the median measured time of the deployed kernel on the selected hardware. All times shown for the median shape of each operator.
     </p>
+
     <div class="flex items-center justify-end mb-3 gap-2">
       <span class="text-xs text-gray-500">T<sub>Prod</sub> hardware:</span>
       <select id="prod-hw-select" class="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-300 focus:border-brand-600 focus:outline-none">
@@ -77,20 +73,25 @@ const prodHardware = ['XPU-A', 'H20'];
         <table class="w-full text-xs" id="roofline-table">
           <thead>
             <tr class="border-b border-gray-800 bg-gray-900/50">
-              <th class="text-left py-2.5 px-3 text-gray-400 font-medium sticky left-0 bg-gray-900/95 z-10">
-                Operator
+              <th class="text-left py-2.5 px-3 text-gray-400 font-medium sticky left-0 bg-gray-900/95 z-10 cursor-pointer hover:text-white select-none" data-rf-sort="id">
+                ID <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-center py-2.5 px-3 text-gray-400 font-medium">
-                Regime
+              <th class="text-left py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-rf-sort="name">
+                Operator <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-right py-2.5 px-3 text-gray-400 font-medium">AI</th>
-              {hardware.map((hw: string) => (
-                <th class="text-right py-2.5 px-3 text-gray-400 font-medium whitespace-nowrap">
-                  T<sub>SOL</sub>({hwShort[hw] || hw})
+              <th class="text-center py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-rf-sort="regime">
+                Regime <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
+              </th>
+              <th class="text-right py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-rf-sort="ai">
+                AI <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
+              </th>
+              {hardware.map((hw: string, i: number) => (
+                <th class="text-right py-2.5 px-3 text-gray-400 font-medium whitespace-nowrap cursor-pointer hover:text-white select-none" data-rf-sort={`sol-${i}`}>
+                  T<sub>SOL</sub>({hwShort[hw] || hw}) <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
                 </th>
               ))}
-              <th class="text-right py-2.5 px-3 text-gray-400 font-medium whitespace-nowrap">
-                T<sub>Prod</sub>
+              <th class="text-right py-2.5 px-3 text-gray-400 font-medium whitespace-nowrap cursor-pointer hover:text-white select-none" data-rf-sort="tprod">
+                T<sub>Prod</sub> <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
             </tr>
           </thead>
@@ -106,17 +107,19 @@ const prodHardware = ['XPU-A', 'H20'];
                 ? 'text-red-300' : regime === 'memory-bound'
                 ? 'text-blue-300' : 'text-gray-500';
 
-              // Production time is per-SKU; build a map so the dropdown can switch
-              // it, and SKUs without a measurement (e.g. H20) render as "—".
               const prodByHw = Object.fromEntries(
                 prodHardware.map((hw) => [hw, op.production_shapes?.[hw]?.[midSid] ?? null])
               );
               const prodTime = prodByHw[prodHardware[0]];
 
               return (
-                <tr class="border-b border-gray-800/30 hover:bg-gray-800/20">
-                  <td class="py-2 px-3 sticky left-0 bg-gray-950 z-10">
-                    <code class="text-white font-mono">{op.name}</code>
+                <tr class="border-b border-gray-800/30 hover:bg-gray-800/30 transition-colors"
+                    data-rf-id={op.id} data-rf-name={op.name} data-rf-regime={regime} data-rf-ai={rs.ai} data-rf-prod={prodTime ?? ''}
+                    data-rf-sols={JSON.stringify((hardware as string[]).map((hw: string) => rs.SOL_time_ms?.[hw] ?? null))}
+                    data-prod-hw={JSON.stringify(prodByHw)}>
+                  <td class="py-2 px-3 sticky left-0 bg-gray-900/95 z-10 text-gray-500 font-mono">{op.id.replace('atrex_', '')}</td>
+                  <td class="py-2 px-3">
+                    <a href={`${base}/operator/${op.id}`} class="hover:underline"><code class="text-white font-mono">{op.name}</code></a>
                   </td>
                   <td class={`py-2 px-3 text-center ${regimeClass}`}>
                     {regime === 'compute-bound' ? 'C' : regime === 'memory-bound' ? 'M' : 'I'}
@@ -136,8 +139,7 @@ const prodHardware = ['XPU-A', 'H20'];
                       </td>
                     );
                   })}
-                  <td class="py-2 px-3 text-right font-mono prod-time-cell"
-                      data-prod-hw={JSON.stringify(prodByHw)}>
+                  <td class="py-2 px-3 text-right font-mono prod-time-cell">
                     {prodTime != null ? (
                       <span class="text-brand-300">
                         {prodTime >= 1000
@@ -154,15 +156,79 @@ const prodHardware = ['XPU-A', 'H20'];
       </div>
     </div>
 
-    <p lang="en" class="text-gray-500 text-xs mt-3">
+    <p class="text-gray-500 text-xs mt-3">
       C = compute-bound (AI &gt; 10 FLOP/byte), M = memory-bound, I = indexing/structural. T<sub>SOL</sub> = Speed-of-Light theoretical minimum. T<sub>Prod</sub> = deployed kernel median time on selected hardware.
     </p>
-    </div>
+
+  </div>
 </div>
 
 <script>
-  // Switch the T_Prod column when the hardware dropdown changes. Production time
-  // is per-SKU; a SKU with no measurement (e.g. H20) renders as "—".
+  const rfTable = document.getElementById('roofline-table');
+  if (rfTable) {
+    const rfTbody = rfTable.querySelector('tbody')!;
+    const rfSortableThs = rfTable.querySelectorAll('[data-rf-sort]');
+    let rfSort = { key: '', asc: true };
+
+    function updateRfArrows() {
+      rfSortableThs.forEach(th => {
+        const arrow = th.querySelector('.sort-arrow');
+        if (!arrow) return;
+        const key = (th as HTMLElement).dataset.rfSort!;
+        if (key === rfSort.key) {
+          arrow.innerHTML = rfSort.asc ? '&#x25B4;' : '&#x25BE;';
+          arrow.classList.remove('text-gray-600');
+          arrow.classList.add('text-white');
+        } else {
+          arrow.innerHTML = '&#x25B4;&#x25BE;';
+          arrow.classList.remove('text-white');
+          arrow.classList.add('text-gray-600');
+        }
+      });
+    }
+
+    rfSortableThs.forEach(th => {
+      th.addEventListener('click', () => {
+        const key = (th as HTMLElement).dataset.rfSort!;
+        if (rfSort.key === key) rfSort.asc = !rfSort.asc;
+        else rfSort = { key, asc: true };
+        updateRfArrows();
+
+        const rows = Array.from(rfTbody.querySelectorAll('tr')) as HTMLElement[];
+        rows.sort((a, b) => {
+          let va: any, vb: any;
+          if (key === 'id') {
+            va = a.dataset.rfId || ''; vb = b.dataset.rfId || '';
+          } else if (key === 'name') {
+            va = a.dataset.rfName || ''; vb = b.dataset.rfName || '';
+          } else if (key === 'regime') {
+            va = a.dataset.rfRegime || ''; vb = b.dataset.rfRegime || '';
+          } else if (key === 'ai') {
+            va = parseFloat(a.dataset.rfAi || '0'); vb = parseFloat(b.dataset.rfAi || '0');
+          } else if (key === 'tprod') {
+            va = parseFloat(a.dataset.rfProd || '-1'); vb = parseFloat(b.dataset.rfProd || '-1');
+          } else if (key.startsWith('sol-')) {
+            const idx = parseInt(key.split('-')[1]);
+            const getSol = (el: HTMLElement) => {
+              const sols = JSON.parse(el.dataset.rfSols || '[]');
+              return sols[idx] ?? -1;
+            };
+            va = getSol(a); vb = getSol(b);
+          }
+          if (va < vb) return rfSort.asc ? -1 : 1;
+          if (va > vb) return rfSort.asc ? 1 : -1;
+          return 0;
+        });
+        rows.forEach(r => rfTbody.appendChild(r));
+      });
+    });
+
+    // Default sort by ID
+    const idTh = rfTable.querySelector('[data-rf-sort="id"]') as HTMLElement;
+    if (idTh) idTh.click();
+  }
+
+  // T_Prod hardware switch
   const prodHwSelect = document.getElementById('prod-hw-select') as HTMLSelectElement | null;
 
   function fmtProd(us: number | null): string {

--- a/site/src/components/ShapeView.astro
+++ b/site/src/components/ShapeView.astro
@@ -1,6 +1,7 @@
 ---
 import operatorData from '../data/operators.json';
-const { operators, hardware } = operatorData;
+const { operators, hardware, hardware_specs } = operatorData;
+const hwSpecs = hardware_specs as Record<string, Record<string, any>>;
 
 const hwShort: Record<string, string> = {
   'XPU-A': 'XPU-A',
@@ -101,8 +102,14 @@ function useMsUnit(sol_us: number | null): boolean {
   return sol_us != null && sol_us >= 1000;
 }
 
-function fmtAs(us: number | null, ms: boolean): string {
+function fmtAs(us: number | null, ms: boolean, hw?: string): string {
   if (us == null) return '—';
+  if (hw) {
+    const floor = hwSpecs[hw]?.launch_overhead_us;
+    if (floor != null && us <= floor + 0.01) {
+      return '< ' + floor.toFixed(1) + ' us';
+    }
+  }
   return ms ? (us / 1000).toFixed(1) + ' ms' : us.toFixed(1) + ' us';
 }
 
@@ -144,7 +151,7 @@ function barW(s: number | null): number {
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
-<div class="page-section">
+<div class="page-section" data-hw-specs={JSON.stringify(hwSpecs)}>
   <div class="page-container">
     <h2 class="section-heading !mt-0">SOL Ratio by Operator &times; Shape</h2>
     <p class="text-gray-400 text-sm mb-2">
@@ -227,7 +234,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
                   <td class="py-2 px-3 text-gray-400 hidden md:table-cell">{op.phase === 'prefill/decode' ? 'both' : (op.phase || '—')}</td>
                   <td class="py-2 px-3 text-right text-gray-300">{op.shapeCount}</td>
                   <td class="py-2 px-3 text-right font-mono text-gray-300 hidden lg:table-cell sv-sol-cell whitespace-nowrap">
-                    {fmtAs(op.medianSol[defaultHw], opMs)}
+                    {fmtAs(op.medianSol[defaultHw], opMs, defaultHw)}
                   </td>
                   <td class="py-2 px-3 text-right font-mono text-gray-300 hidden lg:table-cell sv-prod-cell whitespace-nowrap">
                     {fmtAs(op.medianProd[defaultHw], opMs)}
@@ -263,7 +270,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
                       </div>
                     </td>
                     <td class="py-1.5 px-3 text-right font-mono text-gray-400 hidden lg:table-cell sv-sol-cell whitespace-nowrap">
-                      {fmtAs(sh.sol[defaultHw], shMs)}
+                      {fmtAs(sh.sol[defaultHw], shMs, defaultHw)}
                     </td>
                     <td class="py-1.5 px-3 text-right font-mono text-brand-300 hidden lg:table-cell sv-prod-cell whitespace-nowrap">
                       {fmtAs(sh.prod[defaultHw], shMs)}
@@ -338,14 +345,22 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
   });
 
   // Helpers
+  const hwSpecsClient = JSON.parse(document.querySelector('[data-hw-specs]')?.getAttribute('data-hw-specs') || '{}');
+
   function fmtS(s: number | null): string {
     if (s == null) return '—';
     if (s > 1.0) return (s * 100).toFixed(1) + '% ⚠';
     return (s * 100).toFixed(1) + '%';
   }
 
-  function fmtAs(us: number | null, ms: boolean): string {
+  function fmtAs(us: number | null, ms: boolean, hw?: string): string {
     if (us == null) return '—';
+    if (hw) {
+      const floor = hwSpecsClient[hw]?.launch_overhead_us;
+      if (floor != null && us <= floor + 0.01) {
+        return '< ' + floor.toFixed(1) + ' us';
+      }
+    }
     return ms ? (us / 1000).toFixed(1) + ' ms' : us.toFixed(1) + ' us';
   }
 
@@ -384,7 +399,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       const ms = solRaw != null && solRaw >= 1000;
 
       const solCell = el.querySelector('.sv-sol-cell');
-      if (solCell) solCell.textContent = fmtAs(solRaw, ms);
+      if (solCell) solCell.textContent = fmtAs(solRaw, ms, hw);
 
       const prodMap = JSON.parse((isOperator ? el.dataset.prodHw : el.dataset.prodRawHw) || '{}');
       const prodRaw: number | null = prodMap[hw] ?? null;

--- a/site/src/components/ShapeView.astro
+++ b/site/src/components/ShapeView.astro
@@ -20,6 +20,7 @@ type ShapeEntry = {
 };
 
 type OpRow = {
+  id: string;
   name: string;
   dtype: string;
   phase: string;
@@ -40,7 +41,7 @@ const median = (arr: number[]) => {
 
 for (const op of operators as any[]) {
   const rs = op.roofline_shapes || {};
-  const ps = op.production_shapes || {};   // { sku: { sid: us } }
+  const ps = op.production_shapes || {};
   const shapeIds = Object.keys(rs).sort((a, b) => parseInt(a) - parseInt(b));
   if (shapeIds.length === 0) continue;
 
@@ -66,12 +67,10 @@ for (const op of operators as any[]) {
       sol[hw] = v;
       if (v != null) solsByHw[hw].push(v);
 
-      // Production time is per-SKU; a SKU with no measurement stays null (→ "—").
       const pv = ps[hw]?.[sid] ?? null;
       prod[hw] = pv;
       if (pv != null) prodsByHw[hw].push(pv);
 
-      // S is only meaningful when the same SKU has both a roofline and a measurement.
       const ratio = v != null && pv != null && pv > 0 ? v / pv : null;
       s[hw] = ratio;
       if (ratio != null) sByHw[hw].push(ratio);
@@ -90,7 +89,7 @@ for (const op of operators as any[]) {
   }
 
   rows.push({
-    name: op.name, dtype: op.dtype, phase: op.phase || '',
+    id: op.id, name: op.name, dtype: op.dtype, phase: op.phase || '',
     shapeCount: shapes.length, medianSol, medianProd, medianS, shapes,
   });
 }
@@ -109,6 +108,7 @@ function fmtAs(us: number | null, ms: boolean): string {
 
 function fmtS(s: number | null): string {
   if (s == null) return '—';
+  if (s > 1.0) return (s * 100).toFixed(1) + '% ⚠';
   return (s * 100).toFixed(1) + '%';
 }
 
@@ -140,17 +140,17 @@ function barW(s: number | null): number {
   if (s == null || s <= 0) return 0;
   return Math.min(s * 100, 100);
 }
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
 <div class="page-section">
   <div class="page-container">
-    <h2 class="section-heading !mt-0">
-      <span >SOL Ratio by Operator &times; Shape</span>
-      
-    </h2>
-    <p lang="en" class="text-gray-400 text-sm mb-2">
+    <h2 class="section-heading !mt-0">SOL Ratio by Operator &times; Shape</h2>
+    <p class="text-gray-400 text-sm mb-2">
       Click an operator to expand per-shape details. S = T<sub>SOL</sub> / T<sub>Prod</sub> — higher is better (100% = hardware limit).
     </p>
+
     <div class="flex items-center justify-end mb-3 gap-2">
       <span class="text-xs text-gray-500">Hardware:</span>
       <select id="sv-hw-select" class="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-300 focus:border-brand-600 focus:outline-none">
@@ -169,24 +169,29 @@ function barW(s: number | null): number {
           <thead>
             <tr class="border-b border-gray-800 bg-gray-900/50">
               <th class="text-left py-2.5 px-3 text-gray-400 font-medium w-5"></th>
+              <th class="text-left py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none whitespace-nowrap" data-sv-sort="id">
+                ID <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
+              </th>
               <th class="text-left py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-sv-sort="name">
-                Operator
+                Operator <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-left py-2.5 px-3 text-gray-400 font-medium hidden sm:table-cell">dtype</th>
-              <th class="text-left py-2.5 px-3 text-gray-400 font-medium hidden md:table-cell">
-                Phase
+              <th class="text-left py-2.5 px-3 text-gray-400 font-medium hidden sm:table-cell cursor-pointer hover:text-white select-none" data-sv-sort="dtype">
+                dtype <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-right py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-sv-sort="shapes">
-                Shapes
+              <th class="text-left py-2.5 px-3 text-gray-400 font-medium hidden md:table-cell cursor-pointer hover:text-white select-none" data-sv-sort="phase">
+                Phase <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-right py-2.5 px-3 text-gray-400 font-medium hidden lg:table-cell cursor-pointer hover:text-white select-none" data-sv-sort="sol">
-                T<sub>SOL</sub> (median)
+              <th class="text-right py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none whitespace-nowrap" data-sv-sort="shapes">
+                Shapes <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-right py-2.5 px-3 text-gray-400 font-medium hidden lg:table-cell cursor-pointer hover:text-white select-none" data-sv-sort="prod">
-                T<sub>Prod</sub> (median)
+              <th class="text-right py-2.5 px-3 text-gray-400 font-medium hidden lg:table-cell cursor-pointer hover:text-white select-none whitespace-nowrap" data-sv-sort="sol">
+                T<sub>SOL</sub> (median) <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
-              <th class="text-right py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none" data-sv-sort="s">
-                S (median)
+              <th class="text-right py-2.5 px-3 text-gray-400 font-medium hidden lg:table-cell cursor-pointer hover:text-white select-none whitespace-nowrap" data-sv-sort="prod">
+                T<sub>Prod</sub> (median) <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
+              </th>
+              <th class="text-right py-2.5 px-3 text-gray-400 font-medium cursor-pointer hover:text-white select-none whitespace-nowrap" data-sv-sort="s">
+                S (median) <span class="sort-arrow text-gray-600 ml-1">&#x25B4;&#x25BE;</span>
               </th>
               <th class="py-2.5 px-3 text-gray-400 font-medium hidden sm:table-cell w-24"></th>
             </tr>
@@ -197,7 +202,8 @@ function barW(s: number | null): number {
               return (
               <>
                 <tr class="border-b border-gray-800/30 hover:bg-gray-800/30 transition-colors cursor-pointer sv-operator-row"
-                    data-op={op.name} data-shapes={op.shapeCount}
+                    data-op={op.name} data-op-id={op.id} data-op-dtype={op.dtype} data-op-phase={op.phase || ''}
+                    data-shapes={op.shapeCount}
                     data-sol={op.medianSol[defaultHw] ?? 0}
                     data-prod={op.medianProd[defaultHw] ?? 0}
                     data-s={op.medianS[defaultHw] ?? 0}
@@ -206,8 +212,9 @@ function barW(s: number | null): number {
                     data-s-hw={JSON.stringify(Object.fromEntries((hardware as string[]).map(hw => [hw, op.medianS[hw]])))}
                     >
                   <td class="py-2 px-3 text-gray-500 sv-chevron">&#x25B6;</td>
+                  <td class="py-2 px-3 text-gray-500 font-mono">{op.id.replace('atrex_', '')}</td>
                   <td class="py-2 px-3">
-                    <code class="text-white font-mono">{op.name}</code>
+                    <a href={`${base}/operator/${op.id}`} class="hover:underline"><code class="text-white font-mono">{op.name}</code></a>
                   </td>
                   <td class="py-2 px-3 hidden sm:table-cell">
                     <span class={`badge ${
@@ -217,15 +224,15 @@ function barW(s: number | null): number {
                       op.dtype === 'fp32' ? 'badge-fp32' : 'badge-int32'
                     }`}>{op.dtype}</span>
                   </td>
-                  <td class="py-2 px-3 text-gray-400 hidden md:table-cell">{op.phase || '—'}</td>
+                  <td class="py-2 px-3 text-gray-400 hidden md:table-cell">{op.phase === 'prefill/decode' ? 'both' : (op.phase || '—')}</td>
                   <td class="py-2 px-3 text-right text-gray-300">{op.shapeCount}</td>
-                  <td class="py-2 px-3 text-right font-mono text-gray-300 hidden lg:table-cell sv-sol-cell">
+                  <td class="py-2 px-3 text-right font-mono text-gray-300 hidden lg:table-cell sv-sol-cell whitespace-nowrap">
                     {fmtAs(op.medianSol[defaultHw], opMs)}
                   </td>
-                  <td class="py-2 px-3 text-right font-mono text-gray-300 hidden lg:table-cell sv-prod-cell">
+                  <td class="py-2 px-3 text-right font-mono text-gray-300 hidden lg:table-cell sv-prod-cell whitespace-nowrap">
                     {fmtAs(op.medianProd[defaultHw], opMs)}
                   </td>
-                  <td class="py-2 px-3 text-right sv-s-badge-cell">
+                  <td class="py-2 px-3 text-right sv-s-badge-cell whitespace-nowrap">
                     <span class={`badge text-xs ${sBadgeCls(op.medianS[defaultHw])}`}>
                       {fmtS(op.medianS[defaultHw])}
                     </span>
@@ -248,19 +255,20 @@ function barW(s: number | null): number {
                       data-s-hw={JSON.stringify(Object.fromEntries((hardware as string[]).map(hw => [hw, sh.s[hw]])))}
                       >
                     <td class="py-1.5 px-3"></td>
+                    <td class="py-1.5 px-3"></td>
                     <td class="py-1.5 px-3" colspan="4">
                       <div class="pl-4 border-l-2 border-gray-800">
                         <span class="text-gray-400 font-mono text-xs">#{sh.id}</span>
                         <span class="text-gray-500 ml-2 text-xs">{sh.description}</span>
                       </div>
                     </td>
-                    <td class="py-1.5 px-3 text-right font-mono text-gray-400 hidden lg:table-cell sv-sol-cell">
+                    <td class="py-1.5 px-3 text-right font-mono text-gray-400 hidden lg:table-cell sv-sol-cell whitespace-nowrap">
                       {fmtAs(sh.sol[defaultHw], shMs)}
                     </td>
-                    <td class="py-1.5 px-3 text-right font-mono text-brand-300 hidden lg:table-cell sv-prod-cell">
+                    <td class="py-1.5 px-3 text-right font-mono text-brand-300 hidden lg:table-cell sv-prod-cell whitespace-nowrap">
                       {fmtAs(sh.prod[defaultHw], shMs)}
                     </td>
-                    <td class="py-1.5 px-3 text-right sv-s-text-cell">
+                    <td class="py-1.5 px-3 text-right sv-s-text-cell whitespace-nowrap">
                       <span class={`font-mono text-xs ${sTextCls(sh.s[defaultHw])}`}>
                         {fmtS(sh.s[defaultHw])}
                       </span>
@@ -299,10 +307,7 @@ function barW(s: number | null): number {
         <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-500"></span>
         <span>&lt; 12%</span>
       </div>
-      <span class="ml-auto">
-        <span >S = T<sub>SOL</sub> / T<sub>Prod</sub>. Higher = closer to hardware limit.</span>
-        
-      </span>
+      <span class="ml-auto">S = T<sub>SOL</sub> / T<sub>Prod</sub>. Higher = closer to hardware limit.</span>
     </div>
   </div>
 </div>
@@ -314,7 +319,7 @@ function barW(s: number | null): number {
   // Expand / collapse
   tbody.querySelectorAll('.sv-operator-row').forEach(row => {
     row.addEventListener('click', (e) => {
-      if ((e.target as HTMLElement).closest('select')) return;
+      if ((e.target as HTMLElement).closest('select, a')) return;
       const opName = (row as HTMLElement).dataset.op!;
       const chevron = row.querySelector('.sv-chevron')!;
       const shapes = tbody.querySelectorAll(`.sv-shape-row[data-parent="${opName}"]`);
@@ -335,6 +340,7 @@ function barW(s: number | null): number {
   // Helpers
   function fmtS(s: number | null): string {
     if (s == null) return '—';
+    if (s > 1.0) return (s * 100).toFixed(1) + '% ⚠';
     return (s * 100).toFixed(1) + '%';
   }
 
@@ -416,32 +422,52 @@ function barW(s: number | null): number {
 
   // Sort
   let currentSort = { key: '', asc: true };
+  const svSortableThs = document.getElementById('shape-view-table')!.querySelectorAll('[data-sv-sort]');
 
-  document.getElementById('shape-view-table')!.querySelectorAll('[data-sv-sort]').forEach(th => {
+  function updateSvSortArrows() {
+    svSortableThs.forEach(th => {
+      const arrow = th.querySelector('.sort-arrow');
+      if (!arrow) return;
+      const key = (th as HTMLElement).dataset.svSort!;
+      if (key === currentSort.key) {
+        arrow.innerHTML = currentSort.asc ? '&#x25B4;' : '&#x25BE;';
+        arrow.classList.remove('text-gray-600');
+        arrow.classList.add('text-white');
+      } else {
+        arrow.innerHTML = '&#x25B4;&#x25BE;';
+        arrow.classList.remove('text-white');
+        arrow.classList.add('text-gray-600');
+      }
+    });
+  }
+
+  svSortableThs.forEach(th => {
     th.addEventListener('click', () => {
       const key = (th as HTMLElement).dataset.svSort!;
       if (currentSort.key === key) currentSort.asc = !currentSort.asc;
       else currentSort = { key, asc: true };
+      updateSvSortArrows();
 
       const opRows = Array.from(tbody.querySelectorAll('.sv-operator-row')) as HTMLElement[];
 
       opRows.sort((a, b) => {
         let va: any, vb: any;
-        if (key === 'name') {
-          va = a.dataset.op || '';
-          vb = b.dataset.op || '';
+        if (key === 'id') {
+          va = a.dataset.opId || ''; vb = b.dataset.opId || '';
+        } else if (key === 'name') {
+          va = a.dataset.op || ''; vb = b.dataset.op || '';
+        } else if (key === 'dtype') {
+          va = a.dataset.opDtype || ''; vb = b.dataset.opDtype || '';
+        } else if (key === 'phase') {
+          va = a.dataset.opPhase || ''; vb = b.dataset.opPhase || '';
         } else if (key === 'shapes') {
-          va = parseInt(a.dataset.shapes || '0');
-          vb = parseInt(b.dataset.shapes || '0');
+          va = parseInt(a.dataset.shapes || '0'); vb = parseInt(b.dataset.shapes || '0');
         } else if (key === 'sol') {
-          va = parseFloat(a.dataset.sol || '0');
-          vb = parseFloat(b.dataset.sol || '0');
+          va = parseFloat(a.dataset.sol || '0'); vb = parseFloat(b.dataset.sol || '0');
         } else if (key === 'prod') {
-          va = parseFloat(a.dataset.prod || '0');
-          vb = parseFloat(b.dataset.prod || '0');
+          va = parseFloat(a.dataset.prod || '0'); vb = parseFloat(b.dataset.prod || '0');
         } else if (key === 's') {
-          va = parseFloat(a.dataset.s || '0');
-          vb = parseFloat(b.dataset.s || '0');
+          va = parseFloat(a.dataset.s || '0'); vb = parseFloat(b.dataset.s || '0');
         }
         if (va < vb) return currentSort.asc ? -1 : 1;
         if (va > vb) return currentSort.asc ? 1 : -1;
@@ -457,4 +483,8 @@ function barW(s: number | null): number {
       });
     });
   });
+
+  // Default sort by ID
+  const idTh = document.querySelector('#shape-view-table [data-sv-sort="id"]') as HTMLElement;
+  if (idTh) idTh.click();
 </script>

--- a/site/src/data/operators.json
+++ b/site/src/data/operators.json
@@ -1,0 +1,26949 @@
+{
+  "stats": {
+    "operators": 30,
+    "shapes": 440,
+    "dsls": 4,
+    "hardware": 2,
+    "prod_perf_shapes": 440,
+    "traces_profiled": 1303
+  },
+  "hardware": [
+    "H20",
+    "XPU-A"
+  ],
+  "hardware_specs": {
+    "H20": {
+      "bf16_tflops": 148.0,
+      "fp8_tflops": 296.0,
+      "bw_tb_s": 4.0
+    },
+    "XPU-A": {
+      "bf16_tflops": 232.7,
+      "fp8_tflops": 465.3,
+      "bw_tb_s": 5.3
+    }
+  },
+  "dsl_targets": [
+    "Triton",
+    "Gluon",
+    "FlyDSL",
+    "CuteDSL"
+  ],
+  "operators": [
+    {
+      "name": "unified_attention",
+      "id": "atrex_030",
+      "dtype": "bf16",
+      "framework": "vllm",
+      "symbol": "unified_attention",
+      "module": "vllm.v1.attention.ops.triton_unified_attention",
+      "phase": "prefill/decode",
+      "shapes": 25,
+      "importance": 0.394972,
+      "roofline": {
+        "median_ai": 112.4,
+        "regime": "compute-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 21895577600,
+          "Q_bytes": 187442324,
+          "ai": 116.8,
+          "SOL_time_ms": {
+            "XPU-A": 94.11,
+            "H20": 147.94
+          },
+          "description": "(vLLM TP4), prefill paged attention, seqs=130 heads=10/1 head_dim=128"
+        },
+        "1": {
+          "W_flops": 48843980800,
+          "Q_bytes": 418140564,
+          "ai": 116.8,
+          "SOL_time_ms": {
+            "XPU-A": 209.95,
+            "H20": 330.03
+          },
+          "description": "(vLLM TP4), prefill paged attention, seqs=290 heads=10/1 head_dim=128"
+        },
+        "2": {
+          "W_flops": 81518919680,
+          "Q_bytes": 697862180,
+          "ai": 116.8,
+          "SOL_time_ms": {
+            "XPU-A": 350.39,
+            "H20": 550.8
+          },
+          "description": "(vLLM TP4), prefill paged attention, seqs=484 heads=10/1 head_dim=128"
+        },
+        "3": {
+          "W_flops": 1114112,
+          "Q_bytes": 139280,
+          "ai": 8.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.03,
+            "H20": 0.03
+          },
+          "description": "(vLLM TP4), prefill paged attention, seqs=1 heads=16/1 head_dim=128"
+        },
+        "4": {
+          "W_flops": 17516740608,
+          "Q_bytes": 41484724,
+          "ai": 422.2,
+          "SOL_time_ms": {
+            "XPU-A": 75.29,
+            "H20": 118.36
+          },
+          "description": "(SGLang), causal attention, seq_len=1688 heads=16/16 head_dim=192"
+        },
+        "5": {
+          "W_flops": 323014901760,
+          "Q_bytes": 109120412,
+          "ai": 2960.2,
+          "SOL_time_ms": {
+            "XPU-A": 1388.42,
+            "H20": 2182.53
+          },
+          "description": "(vLLM), causal attention, seq_len=11840 heads=16/16 head_dim=72"
+        },
+        "6": {
+          "W_flops": 1568476815360,
+          "Q_bytes": 253466680,
+          "ai": 6188.1,
+          "SOL_time_ms": {
+            "XPU-A": 6741.79,
+            "H20": 10597.82
+          },
+          "description": "(rtp-llm), causal attention, seq_len=24752 heads=16/16 head_dim=80"
+        },
+        "7": {
+          "W_flops": 5365268480,
+          "Q_bytes": 10543404,
+          "ai": 508.9,
+          "SOL_time_ms": {
+            "XPU-A": 23.06,
+            "H20": 36.25
+          },
+          "description": "(vLLM), causal attention, seq_len=1144 heads=16/2 head_dim=128"
+        },
+        "8": {
+          "W_flops": 6279168000,
+          "Q_bytes": 16128232,
+          "ai": 389.3,
+          "SOL_time_ms": {
+            "XPU-A": 26.99,
+            "H20": 42.43
+          },
+          "description": "(vLLM), causal attention, seq_len=875 heads=16/2 head_dim=256"
+        },
+        "9": {
+          "W_flops": 87312826368,
+          "Q_bytes": 849369892,
+          "ai": 102.8,
+          "SOL_time_ms": {
+            "XPU-A": 375.3,
+            "H20": 589.95
+          },
+          "description": "(vLLM TP1), prefill paged attention, seqs=324 heads=16/4 head_dim=128"
+        },
+        "10": {
+          "W_flops": 188369338368,
+          "Q_bytes": 1832436892,
+          "ai": 102.8,
+          "SOL_time_ms": {
+            "XPU-A": 809.67,
+            "H20": 1272.77
+          },
+          "description": "(vLLM TP1), prefill paged attention, seqs=699 heads=16/4 head_dim=128"
+        },
+        "11": {
+          "W_flops": 278107521024,
+          "Q_bytes": 2705400388,
+          "ai": 102.8,
+          "SOL_time_ms": {
+            "XPU-A": 1195.39,
+            "H20": 1879.1
+          },
+          "description": "(vLLM TP1), prefill paged attention, seqs=1032 heads=16/4 head_dim=128"
+        },
+        "12": {
+          "W_flops": 507168948224,
+          "Q_bytes": 4933685588,
+          "ai": 102.8,
+          "SOL_time_ms": {
+            "XPU-A": 2179.97,
+            "H20": 3426.82
+          },
+          "description": "(vLLM TP1), prefill paged attention, seqs=1882 heads=16/4 head_dim=128"
+        },
+        "13": {
+          "W_flops": 834053079040,
+          "Q_bytes": 8113579644,
+          "ai": 102.8,
+          "SOL_time_ms": {
+            "XPU-A": 3585.01,
+            "H20": 5635.49
+          },
+          "description": "(vLLM TP1), prefill paged attention, seqs=3095 heads=16/4 head_dim=128"
+        },
+        "14": {
+          "W_flops": 43057152,
+          "Q_bytes": 1474592,
+          "ai": 29.2,
+          "SOL_time_ms": {
+            "XPU-A": 0.28,
+            "H20": 0.37
+          },
+          "description": "(vLLM), causal attention, seq_len=72 heads=16/4 head_dim=256"
+        },
+        "15": {
+          "W_flops": 143360,
+          "Q_bytes": 71696,
+          "ai": 2.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.02
+          },
+          "description": "(vLLM), causal attention, seq_len=7 heads=20/20 head_dim=64"
+        },
+        "16": {
+          "W_flops": 8488747008,
+          "Q_bytes": 75498772,
+          "ai": 112.4,
+          "SOL_time_ms": {
+            "XPU-A": 36.49,
+            "H20": 57.36
+          },
+          "description": "(vLLM TP1), prefill paged attention, seqs=18 heads=28/4 head_dim=128"
+        },
+        "17": {
+          "W_flops": 55648452608,
+          "Q_bytes": 494936372,
+          "ai": 112.4,
+          "SOL_time_ms": {
+            "XPU-A": 239.19,
+            "H20": 376.0
+          },
+          "description": "(vLLM TP1), prefill paged attention, seqs=118 heads=28/4 head_dim=128"
+        },
+        "18": {
+          "W_flops": 562143690752,
+          "Q_bytes": 4999696196,
+          "ai": 112.4,
+          "SOL_time_ms": {
+            "XPU-A": 2416.26,
+            "H20": 3798.27
+          },
+          "description": "(vLLM TP1), prefill paged attention, seqs=1192 heads=28/4 head_dim=128"
+        },
+        "19": {
+          "W_flops": 969603547136,
+          "Q_bytes": 8623637060,
+          "ai": 112.4,
+          "SOL_time_ms": {
+            "XPU-A": 4167.65,
+            "H20": 6551.38
+          },
+          "description": "(vLLM TP1), prefill paged attention, seqs=2056 heads=28/4 head_dim=128"
+        },
+        "20": {
+          "W_flops": 324573020160,
+          "Q_bytes": 116012596,
+          "ai": 2797.7,
+          "SOL_time_ms": {
+            "XPU-A": 1395.11,
+            "H20": 2193.06
+          },
+          "description": "(vLLM TP1), prefill paged attention, seqs=1 heads=32/4 head_dim=128"
+        },
+        "21": {
+          "W_flops": 33377009664,
+          "Q_bytes": 41329160,
+          "ai": 807.6,
+          "SOL_time_ms": {
+            "XPU-A": 143.46,
+            "H20": 225.52
+          },
+          "description": "(vLLM TP1), prefill paged attention, seqs=1 heads=32/8 head_dim=128"
+        },
+        "22": {
+          "W_flops": 1391597715456,
+          "Q_bytes": 113258508,
+          "ai": 12286.9,
+          "SOL_time_ms": {
+            "XPU-A": 5981.51,
+            "H20": 9402.69
+          },
+          "description": "(vLLM), causal attention, seq_len=49152 heads=4/4 head_dim=72"
+        },
+        "23": {
+          "W_flops": 216780800,
+          "Q_bytes": 3563572,
+          "ai": 60.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.93,
+            "H20": 1.46
+          },
+          "description": "(vLLM), causal attention, seq_len=145 heads=40/8 head_dim=128"
+        },
+        "24": {
+          "W_flops": 143865454592,
+          "Q_bytes": 54615512,
+          "ai": 2634.2,
+          "SOL_time_ms": {
+            "XPU-A": 618.38,
+            "H20": 972.06
+          },
+          "description": "(SGLang), causal attention, seq_len=5926 heads=8/1 head_dim=256"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 25,
+          "median_us": 4689.4,
+          "min_us": 18.5,
+          "max_us": 160946.6,
+          "framework": "sglang"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 1292.2,
+          "1": 2893.5,
+          "2": 4689.4,
+          "3": 24.8,
+          "4": 1126.7,
+          "5": 38609.7,
+          "6": 70572.8,
+          "7": 258.3,
+          "8": 413.2,
+          "9": 5037.1,
+          "10": 10834.2,
+          "11": 16042.9,
+          "12": 29361.4,
+          "13": 48595.2,
+          "14": 72.2,
+          "15": 18.5,
+          "16": 518.6,
+          "17": 3222.0,
+          "18": 32450.7,
+          "19": 56166.0,
+          "20": 9737.5,
+          "21": 1179.5,
+          "22": 160946.6,
+          "23": 43.7,
+          "24": 5684.4
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self) -> None:\n        super().__init__()\n\n    def forward(self, q: torch.Tensor, k_cache: torch.Tensor, v_cache: torch.Tensor, cu_seqlens_q: torch.Tensor, seqused_k: torch.Tensor, block_table: torch.Tensor) -> torch.Tensor:\n        (num_tokens, num_query_heads, head_size) = q.shape\n        num_kv_heads = k_cache.shape[2]\n        block_size = k_cache.shape[1]\n        num_queries_per_kv = num_query_heads // num_kv_heads\n        num_seqs = seqused_k.numel()\n        device = q.device\n        k_flat = k_cache.contiguous().view(-1, num_kv_heads, head_size)\n        v_flat = v_cache.contiguous().view(-1, num_kv_heads, head_size)\n        q_bounds = cu_seqlens_q.tolist()\n        k_lens = seqused_k.tolist()\n        out = torch.empty(num_tokens, num_query_heads, head_size, dtype=q.dtype, device=device)\n        for seq_idx in range(num_seqs):\n            q_start, q_end = q_bounds[seq_idx], q_bounds[seq_idx + 1]\n            q_len = q_end - q_start\n            kv_len = int(k_lens[seq_idx])\n            if q_len == 0:\n                continue\n            num_kv_blocks = (kv_len + block_size - 1) // block_size\n            flat_indices = []\n            for b in range(num_kv_blocks):\n                block_id = int(block_table[seq_idx, b].item())\n                remaining = min(block_size, kv_len - b * block_size)\n                for t in range(remaining):\n                    flat_indices.append(block_id * block_size + t)\n            flat_idx = torch.tensor(flat_indices, dtype=torch.long, device=device)\n            k_seq = k_flat.index_select(0, flat_idx)\n            v_seq = v_flat.index_select(0, flat_idx)\n            qs = q[q_start:q_end].transpose(0, 1).unsqueeze(0).float()\n            ks = k_seq.transpose(0, 1).unsqueeze(0).float()\n            vs = v_seq.transpose(0, 1).unsqueeze(0).float()\n            if num_queries_per_kv > 1:\n                ks = ks.repeat_interleave(num_queries_per_kv, dim=1)\n                vs = vs.repeat_interleave(num_queries_per_kv, dim=1)\n            is_causal = (q_len == kv_len)\n            os = F.scaled_dot_product_attention(qs, ks, vs, is_causal=is_causal)\n            out[q_start:q_end] = os.squeeze(0).transpose(0, 1).to(q.dtype)\n        return out\n",
+      "input_code": "import torch\n\ndef _make_inputs(num_seqs: int, seq_lens: list[int], num_query_heads: int, num_kv_heads: int, head_size: int, block_size: int) -> dict[str, torch.Tensor]:\n    num_tokens = sum(seq_lens)\n    max_seq_len = max(seq_lens)\n    max_num_blocks = (max_seq_len + block_size - 1) // block_size + 2\n    q = torch.randn(num_tokens, num_query_heads, head_size, dtype=torch.bfloat16, device='cuda')\n    num_blocks = max_num_blocks * num_seqs + 64\n    k_cache = torch.randn(num_blocks, block_size, num_kv_heads, head_size, dtype=torch.bfloat16, device='cuda')\n    v_cache = torch.randn(num_blocks, block_size, num_kv_heads, head_size, dtype=torch.bfloat16, device='cuda')\n    cu_seqlens_q = torch.tensor([0] + [sum(seq_lens[:index + 1]) for index in range(num_seqs)], dtype=torch.int32, device='cuda')\n    seqused_k = torch.tensor(seq_lens, dtype=torch.int32, device='cuda')\n    block_table = torch.zeros(num_seqs, max_num_blocks, dtype=torch.int32, device='cuda')\n    for seq_index in range(num_seqs):\n        num_blocks_needed = (seq_lens[seq_index] + block_size - 1) // block_size\n        block_table[seq_index, :num_blocks_needed] = torch.arange(seq_index * max_num_blocks, seq_index * max_num_blocks + num_blocks_needed, dtype=torch.int32, device='cuda')\n    return {'q': q, 'k_cache': k_cache, 'v_cache': v_cache, 'cu_seqlens_q': cu_seqlens_q, 'seqused_k': seqused_k, 'block_table': block_table}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM TP4), prefill paged attention, seqs=130 heads=10/1 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 130,
+            "seq_lens": [
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256
+            ],
+            "num_query_heads": 10,
+            "num_kv_heads": 1,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 21895577600,
+          "Q_bytes": 187442324,
+          "ai": 116.8,
+          "SOL_time_ms": {
+            "XPU-A": 94.11,
+            "H20": 147.94
+          },
+          "prod_us": {
+            "XPU-A": 1292.2
+          }
+        },
+        "1": {
+          "description": "(vLLM TP4), prefill paged attention, seqs=290 heads=10/1 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 290,
+            "seq_lens": [
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256
+            ],
+            "num_query_heads": 10,
+            "num_kv_heads": 1,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 48843980800,
+          "Q_bytes": 418140564,
+          "ai": 116.8,
+          "SOL_time_ms": {
+            "XPU-A": 209.95,
+            "H20": 330.03
+          },
+          "prod_us": {
+            "XPU-A": 2893.5
+          }
+        },
+        "2": {
+          "description": "(vLLM TP4), prefill paged attention, seqs=484 heads=10/1 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 484,
+            "seq_lens": [
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256
+            ],
+            "num_query_heads": 10,
+            "num_kv_heads": 1,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 81518919680,
+          "Q_bytes": 697862180,
+          "ai": 116.8,
+          "SOL_time_ms": {
+            "XPU-A": 350.39,
+            "H20": 550.8
+          },
+          "prod_us": {
+            "XPU-A": 4689.4
+          }
+        },
+        "3": {
+          "description": "(vLLM TP4), prefill paged attention, seqs=1 heads=16/1 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              16
+            ],
+            "num_query_heads": 16,
+            "num_kv_heads": 1,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 1114112,
+          "Q_bytes": 139280,
+          "ai": 8.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.03,
+            "H20": 0.03
+          },
+          "prod_us": {
+            "XPU-A": 24.8
+          }
+        },
+        "4": {
+          "description": "(SGLang), causal attention, seq_len=1688 heads=16/16 head_dim=192",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              1688
+            ],
+            "num_query_heads": 16,
+            "num_kv_heads": 16,
+            "head_size": 192,
+            "block_size": 16
+          },
+          "W_flops": 17516740608,
+          "Q_bytes": 41484724,
+          "ai": 422.2,
+          "SOL_time_ms": {
+            "XPU-A": 75.29,
+            "H20": 118.36
+          },
+          "prod_us": {
+            "XPU-A": 1126.7
+          }
+        },
+        "5": {
+          "description": "(vLLM), causal attention, seq_len=11840 heads=16/16 head_dim=72",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              11840
+            ],
+            "num_query_heads": 16,
+            "num_kv_heads": 16,
+            "head_size": 72,
+            "block_size": 16
+          },
+          "W_flops": 323014901760,
+          "Q_bytes": 109120412,
+          "ai": 2960.2,
+          "SOL_time_ms": {
+            "XPU-A": 1388.42,
+            "H20": 2182.53
+          },
+          "prod_us": {
+            "XPU-A": 38609.7
+          }
+        },
+        "6": {
+          "description": "(rtp-llm), causal attention, seq_len=24752 heads=16/16 head_dim=80",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              24752
+            ],
+            "num_query_heads": 16,
+            "num_kv_heads": 16,
+            "head_size": 80,
+            "block_size": 16
+          },
+          "W_flops": 1568476815360,
+          "Q_bytes": 253466680,
+          "ai": 6188.1,
+          "SOL_time_ms": {
+            "XPU-A": 6741.79,
+            "H20": 10597.82
+          },
+          "prod_us": {
+            "XPU-A": 70572.8
+          }
+        },
+        "7": {
+          "description": "(vLLM), causal attention, seq_len=1144 heads=16/2 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              1144
+            ],
+            "num_query_heads": 16,
+            "num_kv_heads": 2,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 5365268480,
+          "Q_bytes": 10543404,
+          "ai": 508.9,
+          "SOL_time_ms": {
+            "XPU-A": 23.06,
+            "H20": 36.25
+          },
+          "prod_us": {
+            "XPU-A": 258.3
+          }
+        },
+        "8": {
+          "description": "(vLLM), causal attention, seq_len=875 heads=16/2 head_dim=256",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              875
+            ],
+            "num_query_heads": 16,
+            "num_kv_heads": 2,
+            "head_size": 256,
+            "block_size": 16
+          },
+          "W_flops": 6279168000,
+          "Q_bytes": 16128232,
+          "ai": 389.3,
+          "SOL_time_ms": {
+            "XPU-A": 26.99,
+            "H20": 42.43
+          },
+          "prod_us": {
+            "XPU-A": 413.2
+          }
+        },
+        "9": {
+          "description": "(vLLM TP1), prefill paged attention, seqs=324 heads=16/4 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 324,
+            "seq_lens": [
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256
+            ],
+            "num_query_heads": 16,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 87312826368,
+          "Q_bytes": 849369892,
+          "ai": 102.8,
+          "SOL_time_ms": {
+            "XPU-A": 375.3,
+            "H20": 589.95
+          },
+          "prod_us": {
+            "XPU-A": 5037.1
+          }
+        },
+        "10": {
+          "description": "(vLLM TP1), prefill paged attention, seqs=699 heads=16/4 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 699,
+            "seq_lens": [
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256
+            ],
+            "num_query_heads": 16,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 188369338368,
+          "Q_bytes": 1832436892,
+          "ai": 102.8,
+          "SOL_time_ms": {
+            "XPU-A": 809.67,
+            "H20": 1272.77
+          },
+          "prod_us": {
+            "XPU-A": 10834.2
+          }
+        },
+        "11": {
+          "description": "(vLLM TP1), prefill paged attention, seqs=1032 heads=16/4 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1032,
+            "seq_lens": [
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256
+            ],
+            "num_query_heads": 16,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 278107521024,
+          "Q_bytes": 2705400388,
+          "ai": 102.8,
+          "SOL_time_ms": {
+            "XPU-A": 1195.39,
+            "H20": 1879.1
+          },
+          "prod_us": {
+            "XPU-A": 16042.9
+          }
+        },
+        "12": {
+          "description": "(vLLM TP1), prefill paged attention, seqs=1882 heads=16/4 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1882,
+            "seq_lens": [
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256
+            ],
+            "num_query_heads": 16,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 507168948224,
+          "Q_bytes": 4933685588,
+          "ai": 102.8,
+          "SOL_time_ms": {
+            "XPU-A": 2179.97,
+            "H20": 3426.82
+          },
+          "prod_us": {
+            "XPU-A": 29361.4
+          }
+        },
+        "13": {
+          "description": "(vLLM TP1), prefill paged attention, seqs=3095 heads=16/4 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 3095,
+            "seq_lens": [
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256
+            ],
+            "num_query_heads": 16,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 834053079040,
+          "Q_bytes": 8113579644,
+          "ai": 102.8,
+          "SOL_time_ms": {
+            "XPU-A": 3585.01,
+            "H20": 5635.49
+          },
+          "prod_us": {
+            "XPU-A": 48595.2
+          }
+        },
+        "14": {
+          "description": "(vLLM), causal attention, seq_len=72 heads=16/4 head_dim=256",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              72
+            ],
+            "num_query_heads": 16,
+            "num_kv_heads": 4,
+            "head_size": 256,
+            "block_size": 16
+          },
+          "W_flops": 43057152,
+          "Q_bytes": 1474592,
+          "ai": 29.2,
+          "SOL_time_ms": {
+            "XPU-A": 0.28,
+            "H20": 0.37
+          },
+          "prod_us": {
+            "XPU-A": 72.2
+          }
+        },
+        "15": {
+          "description": "(vLLM), causal attention, seq_len=7 heads=20/20 head_dim=64",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              7
+            ],
+            "num_query_heads": 20,
+            "num_kv_heads": 20,
+            "head_size": 64,
+            "block_size": 16
+          },
+          "W_flops": 143360,
+          "Q_bytes": 71696,
+          "ai": 2.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.02
+          },
+          "prod_us": {
+            "XPU-A": 18.5
+          }
+        },
+        "16": {
+          "description": "(vLLM TP1), prefill paged attention, seqs=18 heads=28/4 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 18,
+            "seq_lens": [
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256
+            ],
+            "num_query_heads": 28,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 8488747008,
+          "Q_bytes": 75498772,
+          "ai": 112.4,
+          "SOL_time_ms": {
+            "XPU-A": 36.49,
+            "H20": 57.36
+          },
+          "prod_us": {
+            "XPU-A": 518.6
+          }
+        },
+        "17": {
+          "description": "(vLLM TP1), prefill paged attention, seqs=118 heads=28/4 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 118,
+            "seq_lens": [
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256
+            ],
+            "num_query_heads": 28,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 55648452608,
+          "Q_bytes": 494936372,
+          "ai": 112.4,
+          "SOL_time_ms": {
+            "XPU-A": 239.19,
+            "H20": 376.0
+          },
+          "prod_us": {
+            "XPU-A": 3222.0
+          }
+        },
+        "18": {
+          "description": "(vLLM TP1), prefill paged attention, seqs=1192 heads=28/4 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1192,
+            "seq_lens": [
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256
+            ],
+            "num_query_heads": 28,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 562143690752,
+          "Q_bytes": 4999696196,
+          "ai": 112.4,
+          "SOL_time_ms": {
+            "XPU-A": 2416.26,
+            "H20": 3798.27
+          },
+          "prod_us": {
+            "XPU-A": 32450.7
+          }
+        },
+        "19": {
+          "description": "(vLLM TP1), prefill paged attention, seqs=2056 heads=28/4 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 2056,
+            "seq_lens": [
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256,
+              256
+            ],
+            "num_query_heads": 28,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 969603547136,
+          "Q_bytes": 8623637060,
+          "ai": 112.4,
+          "SOL_time_ms": {
+            "XPU-A": 4167.65,
+            "H20": 6551.38
+          },
+          "prod_us": {
+            "XPU-A": 56166.0
+          }
+        },
+        "20": {
+          "description": "(vLLM TP1), prefill paged attention, seqs=1 heads=32/4 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              6294
+            ],
+            "num_query_heads": 32,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 324573020160,
+          "Q_bytes": 116012596,
+          "ai": 2797.7,
+          "SOL_time_ms": {
+            "XPU-A": 1395.11,
+            "H20": 2193.06
+          },
+          "prod_us": {
+            "XPU-A": 9737.5
+          }
+        },
+        "21": {
+          "description": "(vLLM TP1), prefill paged attention, seqs=1 heads=32/8 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              2018
+            ],
+            "num_query_heads": 32,
+            "num_kv_heads": 8,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 33377009664,
+          "Q_bytes": 41329160,
+          "ai": 807.6,
+          "SOL_time_ms": {
+            "XPU-A": 143.46,
+            "H20": 225.52
+          },
+          "prod_us": {
+            "XPU-A": 1179.5
+          }
+        },
+        "22": {
+          "description": "(vLLM), causal attention, seq_len=49152 heads=4/4 head_dim=72",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              49152
+            ],
+            "num_query_heads": 4,
+            "num_kv_heads": 4,
+            "head_size": 72,
+            "block_size": 16
+          },
+          "W_flops": 1391597715456,
+          "Q_bytes": 113258508,
+          "ai": 12286.9,
+          "SOL_time_ms": {
+            "XPU-A": 5981.51,
+            "H20": 9402.69
+          },
+          "prod_us": {
+            "XPU-A": 160946.6
+          }
+        },
+        "23": {
+          "description": "(vLLM), causal attention, seq_len=145 heads=40/8 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              145
+            ],
+            "num_query_heads": 40,
+            "num_kv_heads": 8,
+            "head_size": 128,
+            "block_size": 16
+          },
+          "W_flops": 216780800,
+          "Q_bytes": 3563572,
+          "ai": 60.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.93,
+            "H20": 1.46
+          },
+          "prod_us": {
+            "XPU-A": 43.7
+          }
+        },
+        "24": {
+          "description": "(SGLang), causal attention, seq_len=5926 heads=8/1 head_dim=256",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "seq_lens": [
+              5926
+            ],
+            "num_query_heads": 8,
+            "num_kv_heads": 1,
+            "head_size": 256,
+            "block_size": 16
+          },
+          "W_flops": 143865454592,
+          "Q_bytes": 54615512,
+          "ai": 2634.2,
+          "SOL_time_ms": {
+            "XPU-A": 618.38,
+            "H20": 972.06
+          },
+          "prod_us": {
+            "XPU-A": 5684.4
+          }
+        }
+      }
+    },
+    {
+      "name": "fused_moe",
+      "id": "atrex_009",
+      "dtype": "bf16",
+      "framework": "vllm",
+      "symbol": "fused_experts",
+      "module": "vllm.model_executor.layers.fused_moe.fused_moe",
+      "phase": "prefill/decode",
+      "shapes": 23,
+      "importance": 0.113586,
+      "roofline": {
+        "median_ai": 415.5,
+        "regime": "compute-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 6193818792,
+          "Q_bytes": 202987632,
+          "ai": 30.5,
+          "SOL_time_ms": {
+            "XPU-A": 38.3,
+            "H20": 50.75
+          },
+          "description": "(vLLM), MoE expert FFN, tokens=135 hidden=2048 8 experts top-2"
+        },
+        "1": {
+          "W_flops": 13193337336,
+          "Q_bytes": 204734800,
+          "ai": 64.4,
+          "SOL_time_ms": {
+            "XPU-A": 56.71,
+            "H20": 89.14
+          },
+          "description": "(vLLM), MoE expert FFN, tokens=277 hidden=2048 8 experts top-2"
+        },
+        "2": {
+          "W_flops": 31825149600,
+          "Q_bytes": 209545664,
+          "ai": 151.9,
+          "SOL_time_ms": {
+            "XPU-A": 136.79,
+            "H20": 215.03
+          },
+          "description": "(vLLM), MoE expert FFN, tokens=668 hidden=2048 8 experts top-2"
+        },
+        "3": {
+          "W_flops": 48442712040,
+          "Q_bytes": 213913584,
+          "ai": 226.5,
+          "SOL_time_ms": {
+            "XPU-A": 208.22,
+            "H20": 327.32
+          },
+          "description": "(vLLM), MoE expert FFN, tokens=1023 hidden=2048 8 experts top-2"
+        },
+        "4": {
+          "W_flops": 93763336584,
+          "Q_bytes": 225676208,
+          "ai": 415.5,
+          "SOL_time_ms": {
+            "XPU-A": 403.02,
+            "H20": 633.54
+          },
+          "description": "(vLLM), MoE expert FFN, tokens=1979 hidden=2048 8 experts top-2"
+        },
+        "5": {
+          "W_flops": 198177020232,
+          "Q_bytes": 252941872,
+          "ai": 783.5,
+          "SOL_time_ms": {
+            "XPU-A": 851.82,
+            "H20": 1339.03
+          },
+          "description": "(SGLang), MoE expert FFN, tokens=4195 hidden=2048 8 experts top-2"
+        },
+        "6": {
+          "W_flops": 362288038104,
+          "Q_bytes": 295932048,
+          "ai": 1224.2,
+          "SOL_time_ms": {
+            "XPU-A": 1557.22,
+            "H20": 2447.89
+          },
+          "description": "(vLLM), MoE expert FFN, tokens=7689 hidden=2048 8 experts top-2"
+        },
+        "7": {
+          "W_flops": 745171782168,
+          "Q_bytes": 395840528,
+          "ai": 1882.5,
+          "SOL_time_ms": {
+            "XPU-A": 3202.97,
+            "H20": 5034.94
+          },
+          "description": "(SGLang), MoE expert FFN, tokens=15809 hidden=2048 8 experts top-2"
+        },
+        "8": {
+          "W_flops": 75544696,
+          "Q_bytes": 75509824,
+          "ai": 1.0,
+          "SOL_time_ms": {
+            "XPU-A": 14.25,
+            "H20": 18.88
+          },
+          "description": "(rtp-llm TP1), text decoder MoE expert FFN, hidden_states=(1,2048) 128 experts top-8 intermediate=768"
+        },
+        "9": {
+          "W_flops": 176127343872,
+          "Q_bytes": 1237604352,
+          "ai": 142.3,
+          "SOL_time_ms": {
+            "XPU-A": 757.05,
+            "H20": 1190.05
+          },
+          "description": "(vLLM TP1), text decoder MoE expert FFN, hidden_states=(2400,2048) 128 experts top-8 intermediate=768"
+        },
+        "10": {
+          "W_flops": 308201595264,
+          "Q_bytes": 1259776192,
+          "ai": 244.6,
+          "SOL_time_ms": {
+            "XPU-A": 1324.74,
+            "H20": 2082.44
+          },
+          "description": "(SGLang TP1), text decoder MoE expert FFN, hidden_states=(4195,2048) 128 experts top-8 intermediate=768"
+        },
+        "11": {
+          "W_flops": 602417620736,
+          "Q_bytes": 1309147136,
+          "ai": 460.2,
+          "SOL_time_ms": {
+            "XPU-A": 2589.37,
+            "H20": 4070.39
+          },
+          "description": "(vLLM TP1), text decoder MoE expert FFN, hidden_states=(8192,2048) 128 experts top-8 intermediate=768"
+        },
+        "12": {
+          "W_flops": 1161972033664,
+          "Q_bytes": 1403232320,
+          "ai": 828.1,
+          "SOL_time_ms": {
+            "XPU-A": 4994.51,
+            "H20": 7851.16
+          },
+          "description": "(SGLang TP1), text decoder MoE expert FFN, hidden_states=(15809,2048) 128 experts top-8 intermediate=768"
+        },
+        "13": {
+          "W_flops": 1884263141888,
+          "Q_bytes": 1524566016,
+          "ai": 1235.9,
+          "SOL_time_ms": {
+            "XPU-A": 8099.13,
+            "H20": 12731.51
+          },
+          "description": "(vLLM TP1), text decoder MoE expert FFN, hidden_states=(25632,2048) 128 experts top-8 intermediate=768"
+        },
+        "14": {
+          "W_flops": 3377620088576,
+          "Q_bytes": 1775361024,
+          "ai": 1902.5,
+          "SOL_time_ms": {
+            "XPU-A": 14518.03,
+            "H20": 22821.76
+          },
+          "description": "(vLLM TP1), text decoder MoE expert FFN, hidden_states=(45936,2048) 128 experts top-8 intermediate=768"
+        },
+        "15": {
+          "W_flops": 38283731200,
+          "Q_bytes": 1220772352,
+          "ai": 31.4,
+          "SOL_time_ms": {
+            "XPU-A": 230.33,
+            "H20": 305.19
+          },
+          "description": "(vLLM TP4), text decoder MoE expert FFN, hidden_states=(520,4096) 128 experts top-8 intermediate=384"
+        },
+        "16": {
+          "W_flops": 75047066880,
+          "Q_bytes": 1233067712,
+          "ai": 60.9,
+          "SOL_time_ms": {
+            "XPU-A": 322.57,
+            "H20": 507.07
+          },
+          "description": "(vLLM TP4), text decoder MoE expert FFN, hidden_states=(1019,4096) 128 experts top-8 intermediate=384"
+        },
+        "17": {
+          "W_flops": 150301895680,
+          "Q_bytes": 1258323712,
+          "ai": 119.4,
+          "SOL_time_ms": {
+            "XPU-A": 646.04,
+            "H20": 1015.55
+          },
+          "description": "(vLLM TP4), text decoder MoE expert FFN, hidden_states=(2044,4096) 128 experts top-8 intermediate=384"
+        },
+        "18": {
+          "W_flops": 289517182720,
+          "Q_bytes": 1304942592,
+          "ai": 221.9,
+          "SOL_time_ms": {
+            "XPU-A": 1244.43,
+            "H20": 1956.2
+          },
+          "description": "(vLLM TP4), text decoder MoE expert FFN, hidden_states=(3936,4096) 128 experts top-8 intermediate=384"
+        },
+        "19": {
+          "W_flops": 601849751040,
+          "Q_bytes": 1409810432,
+          "ai": 426.9,
+          "SOL_time_ms": {
+            "XPU-A": 2586.93,
+            "H20": 4066.55
+          },
+          "description": "(vLLM TP4), text decoder MoE expert FFN, hidden_states=(8192,4096) 128 experts top-8 intermediate=384"
+        },
+        "20": {
+          "W_flops": 775196024880,
+          "Q_bytes": 906084384,
+          "ai": 855.5,
+          "SOL_time_ms": {
+            "XPU-A": 3332.03,
+            "H20": 5237.81
+          },
+          "description": "(SGLang), MoE expert FFN, tokens=4098 hidden=4096 8 experts top-2"
+        },
+        "21": {
+          "W_flops": 1542941146824,
+          "Q_bytes": 1006444336,
+          "ai": 1533.1,
+          "SOL_time_ms": {
+            "XPU-A": 6632.03,
+            "H20": 10425.28
+          },
+          "description": "(SGLang), MoE expert FFN, tokens=8179 hidden=4096 8 experts top-2"
+        },
+        "22": {
+          "W_flops": 2903939285496,
+          "Q_bytes": 1183555920,
+          "ai": 2453.6,
+          "SOL_time_ms": {
+            "XPU-A": 12482.01,
+            "H20": 19621.21
+          },
+          "description": "(SGLang), MoE expert FFN, tokens=15381 hidden=4096 8 experts top-2"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 23,
+          "median_us": 5694.2,
+          "min_us": 225.9,
+          "max_us": 76815.1,
+          "framework": "sglang"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 300.2,
+          "1": 473.4,
+          "2": 654.1,
+          "3": 947.1,
+          "4": 1461.2,
+          "5": 3109.2,
+          "6": 5987.2,
+          "7": 14360.4,
+          "8": 225.9,
+          "9": 3698.5,
+          "10": 5846.9,
+          "11": 10565.1,
+          "12": 22238.2,
+          "13": 40109.1,
+          "14": 76815.1,
+          "15": 1262.0,
+          "16": 1891.0,
+          "17": 3325.7,
+          "18": 5694.2,
+          "19": 11595.7,
+          "20": 11607.7,
+          "21": 32255.2,
+          "22": 71529.4
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self, num_experts: int, intermediate_size: int, top_k: int) -> None:\n        super().__init__()\n        self.num_experts = num_experts\n        self.intermediate_size = intermediate_size\n        self.top_k = top_k\n\n    def forward(self, hidden_states: torch.Tensor, w1: torch.Tensor, w2: torch.Tensor, topk_weights: torch.Tensor, topk_ids: torch.Tensor) -> torch.Tensor:\n        token_count = hidden_states.shape[0]\n        hidden_size = hidden_states.shape[1]\n        intermediate_size = self.intermediate_size\n        output = torch.zeros(token_count, hidden_size, device=hidden_states.device, dtype=torch.float32)\n        hidden_fp32 = hidden_states.float()\n        for expert_index in range(self.num_experts):\n            mask = topk_ids == expert_index\n            if not mask.any():\n                continue\n            weight_for_expert = (topk_weights * mask.to(topk_weights.dtype)).sum(dim=1)\n            token_idx = weight_for_expert.nonzero(as_tuple=True)[0]\n            if token_idx.numel() == 0:\n                continue\n            x = hidden_fp32.index_select(0, token_idx)\n            w1_e = w1[expert_index].float()\n            w2_e = w2[expert_index].float()\n            intermediate = F.linear(x, w1_e)\n            gate = intermediate[:, :intermediate_size]\n            up = intermediate[:, intermediate_size:]\n            activated = F.silu(gate) * up\n            expert_output = F.linear(activated, w2_e)\n            output.index_add_(0, token_idx, expert_output * weight_for_expert.index_select(0, token_idx).unsqueeze(1))\n        return output\n",
+      "input_code": "import torch\n\ndef _make_inputs(token_count: int, hidden_size: int, intermediate_size: int, num_experts: int, top_k: int) -> dict[str, torch.Tensor]:\n    hidden_states = torch.randn(token_count, hidden_size, dtype=torch.bfloat16, device='cuda') * 0.1\n    w1 = torch.randn(num_experts, 2 * intermediate_size, hidden_size, dtype=torch.bfloat16, device='cuda') * hidden_size ** (-0.5)\n    w2 = torch.randn(num_experts, hidden_size, intermediate_size, dtype=torch.bfloat16, device='cuda') * intermediate_size ** (-0.5)\n    topk_weights = torch.softmax(torch.randn(token_count, top_k, dtype=torch.float32, device='cuda'), dim=-1)\n    topk_ids = torch.randint(0, num_experts, (token_count, top_k), dtype=torch.int32, device='cuda')\n    return {'hidden_states': hidden_states, 'w1': w1, 'w2': w2, 'topk_weights': topk_weights, 'topk_ids': topk_ids}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM), MoE expert FFN, tokens=135 hidden=2048 8 experts top-2",
+          "init_kwargs": {
+            "num_experts": 8,
+            "intermediate_size": 2048,
+            "top_k": 2
+          },
+          "input_kwargs": {
+            "token_count": 135,
+            "hidden_size": 2048,
+            "intermediate_size": 2048,
+            "num_experts": 8,
+            "top_k": 2
+          },
+          "W_flops": 6193818792,
+          "Q_bytes": 202987632,
+          "ai": 30.5,
+          "SOL_time_ms": {
+            "XPU-A": 38.3,
+            "H20": 50.75
+          },
+          "prod_us": {
+            "XPU-A": 300.2
+          }
+        },
+        "1": {
+          "description": "(vLLM), MoE expert FFN, tokens=277 hidden=2048 8 experts top-2",
+          "init_kwargs": {
+            "num_experts": 8,
+            "intermediate_size": 2048,
+            "top_k": 2
+          },
+          "input_kwargs": {
+            "token_count": 277,
+            "hidden_size": 2048,
+            "intermediate_size": 2048,
+            "num_experts": 8,
+            "top_k": 2
+          },
+          "W_flops": 13193337336,
+          "Q_bytes": 204734800,
+          "ai": 64.4,
+          "SOL_time_ms": {
+            "XPU-A": 56.71,
+            "H20": 89.14
+          },
+          "prod_us": {
+            "XPU-A": 473.4
+          }
+        },
+        "2": {
+          "description": "(vLLM), MoE expert FFN, tokens=668 hidden=2048 8 experts top-2",
+          "init_kwargs": {
+            "num_experts": 8,
+            "intermediate_size": 2048,
+            "top_k": 2
+          },
+          "input_kwargs": {
+            "token_count": 668,
+            "hidden_size": 2048,
+            "intermediate_size": 2048,
+            "num_experts": 8,
+            "top_k": 2
+          },
+          "W_flops": 31825149600,
+          "Q_bytes": 209545664,
+          "ai": 151.9,
+          "SOL_time_ms": {
+            "XPU-A": 136.79,
+            "H20": 215.03
+          },
+          "prod_us": {
+            "XPU-A": 654.1
+          }
+        },
+        "3": {
+          "description": "(vLLM), MoE expert FFN, tokens=1023 hidden=2048 8 experts top-2",
+          "init_kwargs": {
+            "num_experts": 8,
+            "intermediate_size": 2048,
+            "top_k": 2
+          },
+          "input_kwargs": {
+            "token_count": 1023,
+            "hidden_size": 2048,
+            "intermediate_size": 2048,
+            "num_experts": 8,
+            "top_k": 2
+          },
+          "W_flops": 48442712040,
+          "Q_bytes": 213913584,
+          "ai": 226.5,
+          "SOL_time_ms": {
+            "XPU-A": 208.22,
+            "H20": 327.32
+          },
+          "prod_us": {
+            "XPU-A": 947.1
+          }
+        },
+        "4": {
+          "description": "(vLLM), MoE expert FFN, tokens=1979 hidden=2048 8 experts top-2",
+          "init_kwargs": {
+            "num_experts": 8,
+            "intermediate_size": 2048,
+            "top_k": 2
+          },
+          "input_kwargs": {
+            "token_count": 1979,
+            "hidden_size": 2048,
+            "intermediate_size": 2048,
+            "num_experts": 8,
+            "top_k": 2
+          },
+          "W_flops": 93763336584,
+          "Q_bytes": 225676208,
+          "ai": 415.5,
+          "SOL_time_ms": {
+            "XPU-A": 403.02,
+            "H20": 633.54
+          },
+          "prod_us": {
+            "XPU-A": 1461.2
+          }
+        },
+        "5": {
+          "description": "(SGLang), MoE expert FFN, tokens=4195 hidden=2048 8 experts top-2",
+          "init_kwargs": {
+            "num_experts": 8,
+            "intermediate_size": 2048,
+            "top_k": 2
+          },
+          "input_kwargs": {
+            "token_count": 4195,
+            "hidden_size": 2048,
+            "intermediate_size": 2048,
+            "num_experts": 8,
+            "top_k": 2
+          },
+          "W_flops": 198177020232,
+          "Q_bytes": 252941872,
+          "ai": 783.5,
+          "SOL_time_ms": {
+            "XPU-A": 851.82,
+            "H20": 1339.03
+          },
+          "prod_us": {
+            "XPU-A": 3109.2
+          }
+        },
+        "6": {
+          "description": "(vLLM), MoE expert FFN, tokens=7689 hidden=2048 8 experts top-2",
+          "init_kwargs": {
+            "num_experts": 8,
+            "intermediate_size": 2048,
+            "top_k": 2
+          },
+          "input_kwargs": {
+            "token_count": 7689,
+            "hidden_size": 2048,
+            "intermediate_size": 2048,
+            "num_experts": 8,
+            "top_k": 2
+          },
+          "W_flops": 362288038104,
+          "Q_bytes": 295932048,
+          "ai": 1224.2,
+          "SOL_time_ms": {
+            "XPU-A": 1557.22,
+            "H20": 2447.89
+          },
+          "prod_us": {
+            "XPU-A": 5987.2
+          }
+        },
+        "7": {
+          "description": "(SGLang), MoE expert FFN, tokens=15809 hidden=2048 8 experts top-2",
+          "init_kwargs": {
+            "num_experts": 8,
+            "intermediate_size": 2048,
+            "top_k": 2
+          },
+          "input_kwargs": {
+            "token_count": 15809,
+            "hidden_size": 2048,
+            "intermediate_size": 2048,
+            "num_experts": 8,
+            "top_k": 2
+          },
+          "W_flops": 745171782168,
+          "Q_bytes": 395840528,
+          "ai": 1882.5,
+          "SOL_time_ms": {
+            "XPU-A": 3202.97,
+            "H20": 5034.94
+          },
+          "prod_us": {
+            "XPU-A": 14360.4
+          }
+        },
+        "8": {
+          "description": "(rtp-llm TP1), text decoder MoE expert FFN, hidden_states=(1,2048) 128 experts top-8 intermediate=768",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 768,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "hidden_size": 2048,
+            "intermediate_size": 768,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 75544696,
+          "Q_bytes": 75509824,
+          "ai": 1.0,
+          "SOL_time_ms": {
+            "XPU-A": 14.25,
+            "H20": 18.88
+          },
+          "prod_us": {
+            "XPU-A": 225.9
+          }
+        },
+        "9": {
+          "description": "(vLLM TP1), text decoder MoE expert FFN, hidden_states=(2400,2048) 128 experts top-8 intermediate=768",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 768,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 2400,
+            "hidden_size": 2048,
+            "intermediate_size": 768,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 176127343872,
+          "Q_bytes": 1237604352,
+          "ai": 142.3,
+          "SOL_time_ms": {
+            "XPU-A": 757.05,
+            "H20": 1190.05
+          },
+          "prod_us": {
+            "XPU-A": 3698.5
+          }
+        },
+        "10": {
+          "description": "(SGLang TP1), text decoder MoE expert FFN, hidden_states=(4195,2048) 128 experts top-8 intermediate=768",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 768,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 4195,
+            "hidden_size": 2048,
+            "intermediate_size": 768,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 308201595264,
+          "Q_bytes": 1259776192,
+          "ai": 244.6,
+          "SOL_time_ms": {
+            "XPU-A": 1324.74,
+            "H20": 2082.44
+          },
+          "prod_us": {
+            "XPU-A": 5846.9
+          }
+        },
+        "11": {
+          "description": "(vLLM TP1), text decoder MoE expert FFN, hidden_states=(8192,2048) 128 experts top-8 intermediate=768",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 768,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 8192,
+            "hidden_size": 2048,
+            "intermediate_size": 768,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 602417620736,
+          "Q_bytes": 1309147136,
+          "ai": 460.2,
+          "SOL_time_ms": {
+            "XPU-A": 2589.37,
+            "H20": 4070.39
+          },
+          "prod_us": {
+            "XPU-A": 10565.1
+          }
+        },
+        "12": {
+          "description": "(SGLang TP1), text decoder MoE expert FFN, hidden_states=(15809,2048) 128 experts top-8 intermediate=768",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 768,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 15809,
+            "hidden_size": 2048,
+            "intermediate_size": 768,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 1161972033664,
+          "Q_bytes": 1403232320,
+          "ai": 828.1,
+          "SOL_time_ms": {
+            "XPU-A": 4994.51,
+            "H20": 7851.16
+          },
+          "prod_us": {
+            "XPU-A": 22238.2
+          }
+        },
+        "13": {
+          "description": "(vLLM TP1), text decoder MoE expert FFN, hidden_states=(25632,2048) 128 experts top-8 intermediate=768",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 768,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 25632,
+            "hidden_size": 2048,
+            "intermediate_size": 768,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 1884263141888,
+          "Q_bytes": 1524566016,
+          "ai": 1235.9,
+          "SOL_time_ms": {
+            "XPU-A": 8099.13,
+            "H20": 12731.51
+          },
+          "prod_us": {
+            "XPU-A": 40109.1
+          }
+        },
+        "14": {
+          "description": "(vLLM TP1), text decoder MoE expert FFN, hidden_states=(45936,2048) 128 experts top-8 intermediate=768",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 768,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 45936,
+            "hidden_size": 2048,
+            "intermediate_size": 768,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 3377620088576,
+          "Q_bytes": 1775361024,
+          "ai": 1902.5,
+          "SOL_time_ms": {
+            "XPU-A": 14518.03,
+            "H20": 22821.76
+          },
+          "prod_us": {
+            "XPU-A": 76815.1
+          }
+        },
+        "15": {
+          "description": "(vLLM TP4), text decoder MoE expert FFN, hidden_states=(520,4096) 128 experts top-8 intermediate=384",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 384,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 520,
+            "hidden_size": 4096,
+            "intermediate_size": 384,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 38283731200,
+          "Q_bytes": 1220772352,
+          "ai": 31.4,
+          "SOL_time_ms": {
+            "XPU-A": 230.33,
+            "H20": 305.19
+          },
+          "prod_us": {
+            "XPU-A": 1262.0
+          }
+        },
+        "16": {
+          "description": "(vLLM TP4), text decoder MoE expert FFN, hidden_states=(1019,4096) 128 experts top-8 intermediate=384",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 384,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 1019,
+            "hidden_size": 4096,
+            "intermediate_size": 384,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 75047066880,
+          "Q_bytes": 1233067712,
+          "ai": 60.9,
+          "SOL_time_ms": {
+            "XPU-A": 322.57,
+            "H20": 507.07
+          },
+          "prod_us": {
+            "XPU-A": 1891.0
+          }
+        },
+        "17": {
+          "description": "(vLLM TP4), text decoder MoE expert FFN, hidden_states=(2044,4096) 128 experts top-8 intermediate=384",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 384,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 2044,
+            "hidden_size": 4096,
+            "intermediate_size": 384,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 150301895680,
+          "Q_bytes": 1258323712,
+          "ai": 119.4,
+          "SOL_time_ms": {
+            "XPU-A": 646.04,
+            "H20": 1015.55
+          },
+          "prod_us": {
+            "XPU-A": 3325.7
+          }
+        },
+        "18": {
+          "description": "(vLLM TP4), text decoder MoE expert FFN, hidden_states=(3936,4096) 128 experts top-8 intermediate=384",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 384,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 3936,
+            "hidden_size": 4096,
+            "intermediate_size": 384,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 289517182720,
+          "Q_bytes": 1304942592,
+          "ai": 221.9,
+          "SOL_time_ms": {
+            "XPU-A": 1244.43,
+            "H20": 1956.2
+          },
+          "prod_us": {
+            "XPU-A": 5694.2
+          }
+        },
+        "19": {
+          "description": "(vLLM TP4), text decoder MoE expert FFN, hidden_states=(8192,4096) 128 experts top-8 intermediate=384",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 384,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 8192,
+            "hidden_size": 4096,
+            "intermediate_size": 384,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 601849751040,
+          "Q_bytes": 1409810432,
+          "ai": 426.9,
+          "SOL_time_ms": {
+            "XPU-A": 2586.93,
+            "H20": 4066.55
+          },
+          "prod_us": {
+            "XPU-A": 11595.7
+          }
+        },
+        "20": {
+          "description": "(SGLang), MoE expert FFN, tokens=4098 hidden=4096 8 experts top-2",
+          "init_kwargs": {
+            "num_experts": 8,
+            "intermediate_size": 4096,
+            "top_k": 2
+          },
+          "input_kwargs": {
+            "token_count": 4098,
+            "hidden_size": 4096,
+            "intermediate_size": 4096,
+            "num_experts": 8,
+            "top_k": 2
+          },
+          "W_flops": 775196024880,
+          "Q_bytes": 906084384,
+          "ai": 855.5,
+          "SOL_time_ms": {
+            "XPU-A": 3332.03,
+            "H20": 5237.81
+          },
+          "prod_us": {
+            "XPU-A": 11607.7
+          }
+        },
+        "21": {
+          "description": "(SGLang), MoE expert FFN, tokens=8179 hidden=4096 8 experts top-2",
+          "init_kwargs": {
+            "num_experts": 8,
+            "intermediate_size": 4096,
+            "top_k": 2
+          },
+          "input_kwargs": {
+            "token_count": 8179,
+            "hidden_size": 4096,
+            "intermediate_size": 4096,
+            "num_experts": 8,
+            "top_k": 2
+          },
+          "W_flops": 1542941146824,
+          "Q_bytes": 1006444336,
+          "ai": 1533.1,
+          "SOL_time_ms": {
+            "XPU-A": 6632.03,
+            "H20": 10425.28
+          },
+          "prod_us": {
+            "XPU-A": 32255.2
+          }
+        },
+        "22": {
+          "description": "(SGLang), MoE expert FFN, tokens=15381 hidden=4096 8 experts top-2",
+          "init_kwargs": {
+            "num_experts": 8,
+            "intermediate_size": 4096,
+            "top_k": 2
+          },
+          "input_kwargs": {
+            "token_count": 15381,
+            "hidden_size": 4096,
+            "intermediate_size": 4096,
+            "num_experts": 8,
+            "top_k": 2
+          },
+          "W_flops": 2903939285496,
+          "Q_bytes": 1183555920,
+          "ai": 2453.6,
+          "SOL_time_ms": {
+            "XPU-A": 12482.01,
+            "H20": 19621.21
+          },
+          "prod_us": {
+            "XPU-A": 71529.4
+          }
+        }
+      }
+    },
+    {
+      "name": "block_scaled_mm",
+      "id": "atrex_002",
+      "dtype": "fp8_e4m3",
+      "framework": "vllm",
+      "symbol": "w8a8_triton_block_scaled_mm",
+      "module": "vllm.model_executor.layers.quantization.utils.fp8_utils",
+      "phase": "prefill/decode",
+      "shapes": 24,
+      "importance": 0.093155,
+      "roofline": {
+        "median_ai": 823.0,
+        "regime": "compute-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 2961217536,
+          "Q_bytes": 7791424,
+          "ai": 380.1,
+          "SOL_time_ms": {
+            "XPU-A": 6.36,
+            "H20": 10.0
+          },
+          "description": "(sglang TP1), FP8 block-scale GEMM, input=(349,2048) group=128x128"
+        },
+        "1": {
+          "W_flops": 8688500736,
+          "Q_bytes": 14746624,
+          "ai": 589.2,
+          "SOL_time_ms": {
+            "XPU-A": 18.67,
+            "H20": 29.35
+          },
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=1024"
+        },
+        "2": {
+          "W_flops": 38461888512,
+          "Q_bytes": 50903360,
+          "ai": 755.6,
+          "SOL_time_ms": {
+            "XPU-A": 82.66,
+            "H20": 129.94
+          },
+          "description": "(vLLM TP4), FP8 block-scaled GEMM inferred, m=4533 n=2048 k=2048"
+        },
+        "3": {
+          "W_flops": 58698289152,
+          "Q_bytes": 75478400,
+          "ai": 777.7,
+          "SOL_time_ms": {
+            "XPU-A": 126.15,
+            "H20": 198.31
+          },
+          "description": "(vLLM TP4), FP8 block-scaled GEMM inferred, m=6918 n=2048 k=2048"
+        },
+        "4": {
+          "W_flops": 173770014720,
+          "Q_bytes": 215221248,
+          "ai": 807.4,
+          "SOL_time_ms": {
+            "XPU-A": 373.46,
+            "H20": 587.06
+          },
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=20480"
+        },
+        "5": {
+          "W_flops": 434425036800,
+          "Q_bytes": 531760128,
+          "ai": 817.0,
+          "SOL_time_ms": {
+            "XPU-A": 933.65,
+            "H20": 1467.65
+          },
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=51200"
+        },
+        "6": {
+          "W_flops": 556064047104,
+          "Q_bytes": 679478272,
+          "ai": 818.4,
+          "SOL_time_ms": {
+            "XPU-A": 1195.07,
+            "H20": 1878.59
+          },
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=65536"
+        },
+        "7": {
+          "W_flops": 834096070656,
+          "Q_bytes": 1017119744,
+          "ai": 820.1,
+          "SOL_time_ms": {
+            "XPU-A": 1792.6,
+            "H20": 2817.89
+          },
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=98304"
+        },
+        "8": {
+          "W_flops": 1007866085376,
+          "Q_bytes": 1228145664,
+          "ai": 820.6,
+          "SOL_time_ms": {
+            "XPU-A": 2166.06,
+            "H20": 3404.95
+          },
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=118784"
+        },
+        "9": {
+          "W_flops": 2128682680320,
+          "Q_bytes": 2589262848,
+          "ai": 822.1,
+          "SOL_time_ms": {
+            "XPU-A": 4574.86,
+            "H20": 7191.5
+          },
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=250880"
+        },
+        "10": {
+          "W_flops": 4379004370944,
+          "Q_bytes": 5322048512,
+          "ai": 822.8,
+          "SOL_time_ms": {
+            "XPU-A": 9411.14,
+            "H20": 14793.93
+          },
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=516096"
+        },
+        "11": {
+          "W_flops": 5977688506368,
+          "Q_bytes": 7263486976,
+          "ai": 823.0,
+          "SOL_time_ms": {
+            "XPU-A": 12846.96,
+            "H20": 20194.89
+          },
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=704512"
+        },
+        "12": {
+          "W_flops": 8044621824,
+          "Q_bytes": 21665408,
+          "ai": 371.3,
+          "SOL_time_ms": {
+            "XPU-A": 17.29,
+            "H20": 27.18
+          },
+          "description": "(sglang TP1), FP8 block-scale GEMM, input=(237,4096) group=128x128"
+        },
+        "13": {
+          "W_flops": 104274591744,
+          "Q_bytes": 80089088,
+          "ai": 1302.0,
+          "SOL_time_ms": {
+            "XPU-A": 224.1,
+            "H20": 352.28
+          },
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=3072"
+        },
+        "14": {
+          "W_flops": 139032788992,
+          "Q_bytes": 101191680,
+          "ai": 1374.0,
+          "SOL_time_ms": {
+            "XPU-A": 298.8,
+            "H20": 469.71
+          },
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=4096"
+        },
+        "15": {
+          "W_flops": 278065577984,
+          "Q_bytes": 185602048,
+          "ai": 1498.2,
+          "SOL_time_ms": {
+            "XPU-A": 597.6,
+            "H20": 939.41
+          },
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=8192"
+        },
+        "16": {
+          "W_flops": 556131155968,
+          "Q_bytes": 354422784,
+          "ai": 1569.1,
+          "SOL_time_ms": {
+            "XPU-A": 1195.21,
+            "H20": 1878.82
+          },
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=16384"
+        },
+        "17": {
+          "W_flops": 834196733952,
+          "Q_bytes": 523243520,
+          "ai": 1594.3,
+          "SOL_time_ms": {
+            "XPU-A": 1792.81,
+            "H20": 2818.23
+          },
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=24576"
+        },
+        "18": {
+          "W_flops": 1668393467904,
+          "Q_bytes": 1029705728,
+          "ai": 1620.3,
+          "SOL_time_ms": {
+            "XPU-A": 3585.63,
+            "H20": 5636.46
+          },
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=49152"
+        },
+        "19": {
+          "W_flops": 2224524623872,
+          "Q_bytes": 1367347200,
+          "ai": 1626.9,
+          "SOL_time_ms": {
+            "XPU-A": 4780.84,
+            "H20": 7515.29
+          },
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=65536"
+        },
+        "20": {
+          "W_flops": 3336786935808,
+          "Q_bytes": 2042630144,
+          "ai": 1633.6,
+          "SOL_time_ms": {
+            "XPU-A": 7171.26,
+            "H20": 11272.93
+          },
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=98304"
+        },
+        "21": {
+          "W_flops": 4449049247744,
+          "Q_bytes": 2717913088,
+          "ai": 1636.9,
+          "SOL_time_ms": {
+            "XPU-A": 9561.68,
+            "H20": 15030.57
+          },
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=131072"
+        },
+        "22": {
+          "W_flops": 8759065706496,
+          "Q_bytes": 5334634496,
+          "ai": 1641.9,
+          "SOL_time_ms": {
+            "XPU-A": 18824.56,
+            "H20": 29591.44
+          },
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=258048"
+        },
+        "23": {
+          "W_flops": 10166772695040,
+          "Q_bytes": 6189289472,
+          "ai": 1642.6,
+          "SOL_time_ms": {
+            "XPU-A": 21849.93,
+            "H20": 34347.21
+          },
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=299520"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 24,
+          "median_us": 5930.8,
+          "min_us": 61.8,
+          "max_us": 75566.1,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 61.8,
+          "1": 73.9,
+          "2": 300.0,
+          "3": 440.4,
+          "4": 1237.3,
+          "5": 3098.0,
+          "6": 3965.6,
+          "7": 5930.8,
+          "8": 7181.3,
+          "9": 15131.5,
+          "10": 31144.1,
+          "11": 42516.4,
+          "12": 118.3,
+          "13": 801.9,
+          "14": 1059.5,
+          "15": 2090.1,
+          "16": 4192.4,
+          "17": 6235.7,
+          "18": 12429.3,
+          "19": 16552.2,
+          "20": 24806.0,
+          "21": 33046.9,
+          "22": 65100.2,
+          "23": 75566.1
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n    _M_CHUNK = 16 * 1024\n\n    def __init__(self, group_n: int, group_k: int) -> None:\n        super().__init__()\n        self.group_n = group_n\n        self.group_k = group_k\n\n    def forward(self, a: torch.Tensor, b: torch.Tensor, a_scales: torch.Tensor, b_scales: torch.Tensor) -> torch.Tensor:\n        (m, k) = a.shape\n        n = b.shape[0]\n        num_k_blocks = k // self.group_k\n        b_blocks = b.float().view(n, num_k_blocks, self.group_k).permute(1, 0, 2).contiguous()\n        b_scale_per_n = b_scales.repeat_interleave(self.group_n, dim=0).t().contiguous()\n        result = torch.empty(m, n, dtype=torch.float32, device=a.device)\n        chunk = min(m, self._M_CHUNK) if m > 0 else 1\n        for mc_start in range(0, m, chunk):\n            mc_end = min(mc_start + chunk, m)\n            cm = mc_end - mc_start\n            a_blocks = a[mc_start:mc_end].float().view(cm, num_k_blocks, self.group_k).permute(1, 0, 2).contiguous()\n            dots = torch.bmm(a_blocks, b_blocks.transpose(-2, -1))\n            a_scale_chunk = a_scales[mc_start:mc_end].t().contiguous()\n            scaled = dots * a_scale_chunk.unsqueeze(-1) * b_scale_per_n.unsqueeze(1)\n            result[mc_start:mc_end] = scaled.sum(dim=0)\n        return result\n",
+      "input_code": "import torch\n_M_CHUNK = 64 * 1024\n\ndef _make_inputs(m: int, n: int, k: int, group_n: int, group_k: int) -> dict[str, torch.Tensor]:\n    fp8_max = torch.finfo(torch.float8_e4m3fn).max\n    b_raw = torch.randn(n, k, dtype=torch.float32, device='cuda')\n    b_max = b_raw.view(n // group_n, group_n, k // group_k, group_k).amax(dim=1).amax(dim=-1)\n    b_scales = torch.clamp(b_max / fp8_max, min=1e-10)\n    b_quant = (b_raw / b_scales.repeat_interleave(group_n, dim=0).repeat_interleave(group_k, dim=1)).clamp(-fp8_max, fp8_max).to(torch.float8_e4m3fn)\n    del b_raw\n    a_quant = torch.empty(m, k, dtype=torch.float8_e4m3fn, device='cuda')\n    a_scales = torch.empty(m, k // group_k, dtype=torch.float32, device='cuda')\n    chunk = min(m, _M_CHUNK) if m > 0 else 1\n    for mc_start in range(0, m, chunk):\n        mc_end = min(mc_start + chunk, m)\n        a_raw_c = torch.randn(mc_end - mc_start, k, dtype=torch.float32, device='cuda')\n        a_max_c = a_raw_c.abs().view(mc_end - mc_start, k // group_k, group_k).amax(dim=-1)\n        a_scales_c = torch.clamp(a_max_c / fp8_max, min=1e-10)\n        a_quant_c = (a_raw_c / a_scales_c.repeat_interleave(group_k, dim=1)).clamp(-fp8_max, fp8_max).to(torch.float8_e4m3fn)\n        a_quant[mc_start:mc_end] = a_quant_c\n        a_scales[mc_start:mc_end] = a_scales_c\n    return {'a': a_quant, 'b': b_quant, 'a_scales': a_scales, 'b_scales': b_scales}\n",
+      "shape_details": {
+        "0": {
+          "description": "(sglang TP1), FP8 block-scale GEMM, input=(349,2048) group=128x128",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 349,
+            "n": 2048,
+            "k": 2048,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 2961217536,
+          "Q_bytes": 7791424,
+          "ai": 380.1,
+          "SOL_time_ms": {
+            "XPU-A": 6.36,
+            "H20": 10.0
+          },
+          "prod_us": {
+            "XPU-A": 61.8
+          }
+        },
+        "1": {
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=1024",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 1024,
+            "n": 2048,
+            "k": 2048,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 8688500736,
+          "Q_bytes": 14746624,
+          "ai": 589.2,
+          "SOL_time_ms": {
+            "XPU-A": 18.67,
+            "H20": 29.35
+          },
+          "prod_us": {
+            "XPU-A": 73.9
+          }
+        },
+        "2": {
+          "description": "(vLLM TP4), FP8 block-scaled GEMM inferred, m=4533 n=2048 k=2048",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 4533,
+            "n": 2048,
+            "k": 2048,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 38461888512,
+          "Q_bytes": 50903360,
+          "ai": 755.6,
+          "SOL_time_ms": {
+            "XPU-A": 82.66,
+            "H20": 129.94
+          },
+          "prod_us": {
+            "XPU-A": 300.0
+          }
+        },
+        "3": {
+          "description": "(vLLM TP4), FP8 block-scaled GEMM inferred, m=6918 n=2048 k=2048",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 6918,
+            "n": 2048,
+            "k": 2048,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 58698289152,
+          "Q_bytes": 75478400,
+          "ai": 777.7,
+          "SOL_time_ms": {
+            "XPU-A": 126.15,
+            "H20": 198.31
+          },
+          "prod_us": {
+            "XPU-A": 440.4
+          }
+        },
+        "4": {
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=20480",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 20480,
+            "n": 2048,
+            "k": 2048,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 173770014720,
+          "Q_bytes": 215221248,
+          "ai": 807.4,
+          "SOL_time_ms": {
+            "XPU-A": 373.46,
+            "H20": 587.06
+          },
+          "prod_us": {
+            "XPU-A": 1237.3
+          }
+        },
+        "5": {
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=51200",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 51200,
+            "n": 2048,
+            "k": 2048,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 434425036800,
+          "Q_bytes": 531760128,
+          "ai": 817.0,
+          "SOL_time_ms": {
+            "XPU-A": 933.65,
+            "H20": 1467.65
+          },
+          "prod_us": {
+            "XPU-A": 3098.0
+          }
+        },
+        "6": {
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=65536",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 65536,
+            "n": 2048,
+            "k": 2048,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 556064047104,
+          "Q_bytes": 679478272,
+          "ai": 818.4,
+          "SOL_time_ms": {
+            "XPU-A": 1195.07,
+            "H20": 1878.59
+          },
+          "prod_us": {
+            "XPU-A": 3965.6
+          }
+        },
+        "7": {
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=98304",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 98304,
+            "n": 2048,
+            "k": 2048,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 834096070656,
+          "Q_bytes": 1017119744,
+          "ai": 820.1,
+          "SOL_time_ms": {
+            "XPU-A": 1792.6,
+            "H20": 2817.89
+          },
+          "prod_us": {
+            "XPU-A": 5930.8
+          }
+        },
+        "8": {
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=118784",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 118784,
+            "n": 2048,
+            "k": 2048,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 1007866085376,
+          "Q_bytes": 1228145664,
+          "ai": 820.6,
+          "SOL_time_ms": {
+            "XPU-A": 2166.06,
+            "H20": 3404.95
+          },
+          "prod_us": {
+            "XPU-A": 7181.3
+          }
+        },
+        "9": {
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=250880",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 250880,
+            "n": 2048,
+            "k": 2048,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 2128682680320,
+          "Q_bytes": 2589262848,
+          "ai": 822.1,
+          "SOL_time_ms": {
+            "XPU-A": 4574.86,
+            "H20": 7191.5
+          },
+          "prod_us": {
+            "XPU-A": 15131.5
+          }
+        },
+        "10": {
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=516096",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 516096,
+            "n": 2048,
+            "k": 2048,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 4379004370944,
+          "Q_bytes": 5322048512,
+          "ai": 822.8,
+          "SOL_time_ms": {
+            "XPU-A": 9411.14,
+            "H20": 14793.93
+          },
+          "prod_us": {
+            "XPU-A": 31144.1
+          }
+        },
+        "11": {
+          "description": "(vLLM TP1), FP8 block-scale GEMM (triton), m=704512",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 704512,
+            "n": 2048,
+            "k": 2048,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 5977688506368,
+          "Q_bytes": 7263486976,
+          "ai": 823.0,
+          "SOL_time_ms": {
+            "XPU-A": 12846.96,
+            "H20": 20194.89
+          },
+          "prod_us": {
+            "XPU-A": 42516.4
+          }
+        },
+        "12": {
+          "description": "(sglang TP1), FP8 block-scale GEMM, input=(237,4096) group=128x128",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 237,
+            "n": 4096,
+            "k": 4096,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 8044621824,
+          "Q_bytes": 21665408,
+          "ai": 371.3,
+          "SOL_time_ms": {
+            "XPU-A": 17.29,
+            "H20": 27.18
+          },
+          "prod_us": {
+            "XPU-A": 118.3
+          }
+        },
+        "13": {
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=3072",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 3072,
+            "n": 4096,
+            "k": 4096,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 104274591744,
+          "Q_bytes": 80089088,
+          "ai": 1302.0,
+          "SOL_time_ms": {
+            "XPU-A": 224.1,
+            "H20": 352.28
+          },
+          "prod_us": {
+            "XPU-A": 801.9
+          }
+        },
+        "14": {
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=4096",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 4096,
+            "n": 4096,
+            "k": 4096,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 139032788992,
+          "Q_bytes": 101191680,
+          "ai": 1374.0,
+          "SOL_time_ms": {
+            "XPU-A": 298.8,
+            "H20": 469.71
+          },
+          "prod_us": {
+            "XPU-A": 1059.5
+          }
+        },
+        "15": {
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=8192",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 8192,
+            "n": 4096,
+            "k": 4096,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 278065577984,
+          "Q_bytes": 185602048,
+          "ai": 1498.2,
+          "SOL_time_ms": {
+            "XPU-A": 597.6,
+            "H20": 939.41
+          },
+          "prod_us": {
+            "XPU-A": 2090.1
+          }
+        },
+        "16": {
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=16384",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 16384,
+            "n": 4096,
+            "k": 4096,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 556131155968,
+          "Q_bytes": 354422784,
+          "ai": 1569.1,
+          "SOL_time_ms": {
+            "XPU-A": 1195.21,
+            "H20": 1878.82
+          },
+          "prod_us": {
+            "XPU-A": 4192.4
+          }
+        },
+        "17": {
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=24576",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 24576,
+            "n": 4096,
+            "k": 4096,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 834196733952,
+          "Q_bytes": 523243520,
+          "ai": 1594.3,
+          "SOL_time_ms": {
+            "XPU-A": 1792.81,
+            "H20": 2818.23
+          },
+          "prod_us": {
+            "XPU-A": 6235.7
+          }
+        },
+        "18": {
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=49152",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 49152,
+            "n": 4096,
+            "k": 4096,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 1668393467904,
+          "Q_bytes": 1029705728,
+          "ai": 1620.3,
+          "SOL_time_ms": {
+            "XPU-A": 3585.63,
+            "H20": 5636.46
+          },
+          "prod_us": {
+            "XPU-A": 12429.3
+          }
+        },
+        "19": {
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=65536",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 65536,
+            "n": 4096,
+            "k": 4096,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 2224524623872,
+          "Q_bytes": 1367347200,
+          "ai": 1626.9,
+          "SOL_time_ms": {
+            "XPU-A": 4780.84,
+            "H20": 7515.29
+          },
+          "prod_us": {
+            "XPU-A": 16552.2
+          }
+        },
+        "20": {
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=98304",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 98304,
+            "n": 4096,
+            "k": 4096,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 3336786935808,
+          "Q_bytes": 2042630144,
+          "ai": 1633.6,
+          "SOL_time_ms": {
+            "XPU-A": 7171.26,
+            "H20": 11272.93
+          },
+          "prod_us": {
+            "XPU-A": 24806.0
+          }
+        },
+        "21": {
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=131072",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 131072,
+            "n": 4096,
+            "k": 4096,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 4449049247744,
+          "Q_bytes": 2717913088,
+          "ai": 1636.9,
+          "SOL_time_ms": {
+            "XPU-A": 9561.68,
+            "H20": 15030.57
+          },
+          "prod_us": {
+            "XPU-A": 33046.9
+          }
+        },
+        "22": {
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=258048",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 258048,
+            "n": 4096,
+            "k": 4096,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 8759065706496,
+          "Q_bytes": 5334634496,
+          "ai": 1641.9,
+          "SOL_time_ms": {
+            "XPU-A": 18824.56,
+            "H20": 29591.44
+          },
+          "prod_us": {
+            "XPU-A": 65100.2
+          }
+        },
+        "23": {
+          "description": "(SGLang TP8), FP8 block-scale GEMM, m=299520",
+          "init_kwargs": {
+            "group_n": 128,
+            "group_k": 128
+          },
+          "input_kwargs": {
+            "m": 299520,
+            "n": 4096,
+            "k": 4096,
+            "group_n": 128,
+            "group_k": 128
+          },
+          "W_flops": 10166772695040,
+          "Q_bytes": 6189289472,
+          "ai": 1642.6,
+          "SOL_time_ms": {
+            "XPU-A": 21849.93,
+            "H20": 34347.21
+          },
+          "prod_us": {
+            "XPU-A": 75566.1
+          }
+        }
+      }
+    },
+    {
+      "name": "fp8_blockscale_fused_moe",
+      "id": "atrex_006",
+      "dtype": "fp8_e4m3",
+      "framework": "aiter",
+      "symbol": "fmoe_fp8_blockscale_g1u1",
+      "module": "aiter.ops.moe_op",
+      "phase": "prefill/decode",
+      "shapes": 6,
+      "importance": 0.051305,
+      "roofline": {
+        "median_ai": 237.6,
+        "regime": "compute-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 2329468327936,
+          "Q_bytes": 734315136,
+          "ai": 3172.3,
+          "SOL_time_ms": {
+            "XPU-A": 5006.38,
+            "H20": 7869.83
+          },
+          "description": "(sglang TP1), FP8 block-scale MoE expert FFN, hidden_states=(30821,2048) 128 experts top-8"
+        },
+        "1": {
+          "W_flops": 2692484431872,
+          "Q_bytes": 11332671360,
+          "ai": 237.6,
+          "SOL_time_ms": {
+            "XPU-A": 5786.56,
+            "H20": 9096.23
+          },
+          "description": "(sglang TP2), FP8 block-scale MoE expert FFN, hidden_states=(3804,7168) 256 experts top-8"
+        },
+        "2": {
+          "W_flops": 1057161216,
+          "Q_bytes": 352422176,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 66.49,
+            "H20": 88.11
+          },
+          "description": "(SGLang TP8), FP8 block-scale MoE expert FFN, grid_x=0"
+        },
+        "3": {
+          "W_flops": 29777461248,
+          "Q_bytes": 7224822784,
+          "ai": 4.1,
+          "SOL_time_ms": {
+            "XPU-A": 1363.17,
+            "H20": 1806.21
+          },
+          "description": "(SGLang TP8), FP8 block-scale MoE expert FFN, grid_x=1"
+        },
+        "4": {
+          "W_flops": 453111808,
+          "Q_bytes": 151040192,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 28.5,
+            "H20": 37.76
+          },
+          "description": "(SGLang TP8), FP8 block-scale MoE expert FFN, grid_x=0"
+        },
+        "5": {
+          "W_flops": 775835090944,
+          "Q_bytes": 2437971968,
+          "ai": 318.2,
+          "SOL_time_ms": {
+            "XPU-A": 1667.39,
+            "H20": 2621.06
+          },
+          "description": "(SGLang TP8), FP8 block-scale MoE expert FFN, grid_x=80"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 6,
+          "median_us": 4096.0,
+          "min_us": 238.4,
+          "max_us": 13544.6,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 12622.3,
+          "1": 13544.6,
+          "2": 242.6,
+          "3": 2141.6,
+          "4": 238.4,
+          "5": 4096.0
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self, num_experts: int, intermediate_size: int, top_k: int, scale_block_n: int=128, scale_block_k: int=128) -> None:\n        super().__init__()\n        self.num_experts = num_experts\n        self.intermediate_size = intermediate_size\n        self.top_k = top_k\n        self.scale_block_n = scale_block_n\n        self.scale_block_k = scale_block_k\n\n    def forward(self, hidden_states: torch.Tensor, w1: torch.Tensor, w2: torch.Tensor, topk_weights: torch.Tensor, topk_ids: torch.Tensor, a_scale: torch.Tensor, fc1_scale: torch.Tensor, fc2_scale: torch.Tensor) -> torch.Tensor:\n        (B, D) = hidden_states.shape\n        top_k = topk_ids.shape[1]\n        (expert, model_dim, inter_dim) = w2.shape\n        blk_n = self.scale_block_n\n        blk_k = self.scale_block_k\n        h = hidden_states.float()\n        h = h.view(B, -1, blk_k) * a_scale.unsqueeze(-1)\n        h = h.view(B, -1)\n        nblk_n = inter_dim // blk_n\n        nblk_k = model_dim // blk_k\n        fc1_s = fc1_scale.view(-1, 1).repeat(1, blk_n * blk_k).view(expert, -1, nblk_k, blk_n, blk_k)\n        fc1_s = fc1_s.permute(0, 1, 3, 2, 4).reshape(expert, -1, model_dim)\n        w1_dq = w1.float() * fc1_s\n        fc2_s = fc2_scale.view(-1, 1).repeat(1, blk_k * blk_n).view(expert, nblk_k, nblk_n, blk_k, blk_n)\n        fc2_s = fc2_s.permute(0, 1, 3, 2, 4).reshape(expert, model_dim, inter_dim)\n        w2_dq = w2.float() * fc2_s\n        h = h.view(B, 1, model_dim).repeat(1, top_k, 1)\n        out = torch.zeros(B, top_k, D, dtype=torch.float32, device=hidden_states.device)\n        for eid in range(expert):\n            mask = topk_ids == eid\n            if not mask.any():\n                continue\n            tokens = h[mask]\n            act_input = tokens @ w1_dq[eid].T\n            (gate, up) = act_input.split([inter_dim, inter_dim], dim=-1)\n            act_out = F.silu(gate) * up\n            out[mask] = act_out @ w2_dq[eid].T\n        return (out * topk_weights.view(B, -1, 1)).sum(dim=1).to(hidden_states.dtype)\n",
+      "input_code": "import torch\n\ndef _make_inputs(token_count: int, hidden_size: int, intermediate_size: int, num_experts: int, top_k: int, scale_block_n: int=128, scale_block_k: int=128) -> dict[str, torch.Tensor]:\n    dt = torch.float8_e4m3fnuz\n    fp8_max = torch.finfo(dt).max\n    blk_n = scale_block_n\n    blk_k = scale_block_k\n    nblk_h_k = hidden_size // blk_k\n    nblk_i_n = intermediate_size // blk_n\n    nblk_2i_n = (intermediate_size * 2) // blk_n\n\n    def _block_quant(x_fp32: torch.Tensor, group_dims: tuple) -> tuple:\n        amax = x_fp32.abs().amax(dim=group_dims, keepdim=True).clamp(min=1e-12)\n        scale = amax / fp8_max\n        q = (x_fp32 / scale).clamp(-fp8_max, fp8_max).to(dt)\n        return q, scale\n\n    hidden_bf = torch.randn(token_count, hidden_size, dtype=torch.bfloat16, device='cuda') * 0.03\n    h_blocks = hidden_bf.float().view(token_count, nblk_h_k, blk_k)\n    h_q, h_scale = _block_quant(h_blocks, group_dims=(-1,))\n    hidden_states = h_q.view(token_count, hidden_size)\n    a_scale = h_scale.squeeze(-1).to(torch.float32)\n\n    w1_bf = torch.randn(num_experts, intermediate_size * 2, hidden_size, dtype=torch.bfloat16, device='cuda')\n    w1_blocks = w1_bf.float().view(num_experts, nblk_2i_n, blk_n, nblk_h_k, blk_k)\n    w1_q, w1_scale = _block_quant(w1_blocks, group_dims=(2, 4))\n    w1 = w1_q.view(num_experts, intermediate_size * 2, hidden_size)\n    fc1_scale = w1_scale.squeeze(2).squeeze(-1).to(torch.float32)\n\n    w2_bf = torch.randn(num_experts, hidden_size, intermediate_size, dtype=torch.bfloat16, device='cuda')\n    w2_blocks = w2_bf.float().view(num_experts, nblk_h_k, blk_k, nblk_i_n, blk_n)\n    w2_q, w2_scale = _block_quant(w2_blocks, group_dims=(2, 4))\n    w2 = w2_q.view(num_experts, hidden_size, intermediate_size)\n    fc2_scale = w2_scale.squeeze(2).squeeze(-1).to(torch.float32)\n\n    topk_ids = torch.topk(torch.rand(token_count, num_experts, device='cuda'), top_k, dim=1).indices.to(torch.int32)\n    topk_weights = torch.softmax(torch.randn(token_count, top_k, device='cuda'), dim=-1).to(torch.float32)\n\n    return {'hidden_states': hidden_states, 'w1': w1, 'w2': w2, 'topk_weights': topk_weights, 'topk_ids': topk_ids, 'a_scale': a_scale, 'fc1_scale': fc1_scale, 'fc2_scale': fc2_scale}\n\ndef get_inputs() -> list[torch.Tensor]:\n    return list(_make_inputs(token_count=32, hidden_size=2048, intermediate_size=768, num_experts=128, top_k=8).values())\n\ndef get_init_inputs() -> dict[str, object]:\n    return {'num_experts': 128, 'intermediate_size': 768, 'top_k': 8}\n",
+      "shape_details": {
+        "0": {
+          "description": "(sglang TP1), FP8 block-scale MoE expert FFN, hidden_states=(30821,2048) 128 experts top-8",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 768,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 30821,
+            "hidden_size": 2048,
+            "intermediate_size": 768,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 2329468327936,
+          "Q_bytes": 734315136,
+          "ai": 3172.3,
+          "SOL_time_ms": {
+            "XPU-A": 5006.38,
+            "H20": 7869.83
+          },
+          "prod_us": {
+            "XPU-A": 12622.3
+          }
+        },
+        "1": {
+          "description": "(sglang TP2), FP8 block-scale MoE expert FFN, hidden_states=(3804,7168) 256 experts top-8",
+          "init_kwargs": {
+            "num_experts": 256,
+            "intermediate_size": 2048,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 3804,
+            "hidden_size": 7168,
+            "intermediate_size": 2048,
+            "num_experts": 256,
+            "top_k": 8
+          },
+          "W_flops": 2692484431872,
+          "Q_bytes": 11332671360,
+          "ai": 237.6,
+          "SOL_time_ms": {
+            "XPU-A": 5786.56,
+            "H20": 9096.23
+          },
+          "prod_us": {
+            "XPU-A": 13544.6
+          }
+        },
+        "2": {
+          "description": "(SGLang TP8), FP8 block-scale MoE expert FFN, grid_x=0",
+          "init_kwargs": {
+            "num_experts": 256,
+            "intermediate_size": 2048,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "hidden_size": 7168,
+            "intermediate_size": 2048,
+            "num_experts": 256,
+            "top_k": 8
+          },
+          "W_flops": 1057161216,
+          "Q_bytes": 352422176,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 66.49,
+            "H20": 88.11
+          },
+          "prod_us": {
+            "XPU-A": 242.6
+          }
+        },
+        "3": {
+          "description": "(SGLang TP8), FP8 block-scale MoE expert FFN, grid_x=1",
+          "init_kwargs": {
+            "num_experts": 256,
+            "intermediate_size": 2048,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 32,
+            "hidden_size": 7168,
+            "intermediate_size": 2048,
+            "num_experts": 256,
+            "top_k": 8
+          },
+          "W_flops": 29777461248,
+          "Q_bytes": 7224822784,
+          "ai": 4.1,
+          "SOL_time_ms": {
+            "XPU-A": 1363.17,
+            "H20": 1806.21
+          },
+          "prod_us": {
+            "XPU-A": 2141.6
+          }
+        },
+        "4": {
+          "description": "(SGLang TP8), FP8 block-scale MoE expert FFN, grid_x=0",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 1536,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "hidden_size": 4096,
+            "intermediate_size": 1536,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 453111808,
+          "Q_bytes": 151040192,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 28.5,
+            "H20": 37.76
+          },
+          "prod_us": {
+            "XPU-A": 238.4
+          }
+        },
+        "5": {
+          "description": "(SGLang TP8), FP8 block-scale MoE expert FFN, grid_x=80",
+          "init_kwargs": {
+            "num_experts": 128,
+            "intermediate_size": 1536,
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 2560,
+            "hidden_size": 4096,
+            "intermediate_size": 1536,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 775835090944,
+          "Q_bytes": 2437971968,
+          "ai": 318.2,
+          "SOL_time_ms": {
+            "XPU-A": 1667.39,
+            "H20": 2621.06
+          },
+          "prod_us": {
+            "XPU-A": 4096.0
+          }
+        }
+      }
+    },
+    {
+      "name": "paged_attention_decode",
+      "id": "atrex_024",
+      "dtype": "bf16",
+      "framework": "rtp-llm",
+      "symbol": "paged_attention_rocm",
+      "module": "aiter.paged_attention_rocm",
+      "phase": "decode",
+      "shapes": 8,
+      "importance": 0.044119,
+      "roofline": {
+        "median_ai": 2.6,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 134250496,
+          "Q_bytes": 138417152,
+          "ai": 1.0,
+          "SOL_time_ms": {
+            "XPU-A": 26.12,
+            "H20": 34.6
+          },
+          "description": "(vLLM), decode paged attention, heads=16/16 head_dim=128 ctx_len=64"
+        },
+        "1": {
+          "W_flops": 2097408,
+          "Q_bytes": 802852,
+          "ai": 2.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.15,
+            "H20": 0.2
+          },
+          "description": "(SGLang TP1), decode paged attention, heads=16/2 head_dim=256"
+        },
+        "2": {
+          "W_flops": 12599296,
+          "Q_bytes": 13175296,
+          "ai": 1.0,
+          "SOL_time_ms": {
+            "XPU-A": 2.49,
+            "H20": 3.29
+          },
+          "description": "(vLLM), decode paged attention, heads=3/3 head_dim=128 ctx_len=64"
+        },
+        "3": {
+          "W_flops": 8389632,
+          "Q_bytes": 1638544,
+          "ai": 5.1,
+          "SOL_time_ms": {
+            "XPU-A": 0.31,
+            "H20": 0.41
+          },
+          "description": "(rtp-llm TP1), decode paged attention, heads=32/4 head_dim=128"
+        },
+        "4": {
+          "W_flops": 8389632,
+          "Q_bytes": 3211408,
+          "ai": 2.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.61,
+            "H20": 0.8
+          },
+          "description": "(rtp-llm TP1), decode paged attention, heads=32/8 head_dim=128"
+        },
+        "5": {
+          "W_flops": 262400,
+          "Q_bytes": 198692,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.04,
+            "H20": 0.05
+          },
+          "description": "(SGLang TP8), decode paged attention, heads=4/1 head_dim=128"
+        },
+        "6": {
+          "W_flops": 10486784,
+          "Q_bytes": 3227792,
+          "ai": 3.2,
+          "SOL_time_ms": {
+            "XPU-A": 0.61,
+            "H20": 0.81
+          },
+          "description": "(rtp-llm TP1), decode paged attention, heads=40/8 head_dim=128"
+        },
+        "7": {
+          "W_flops": 16778240,
+          "Q_bytes": 3276944,
+          "ai": 5.1,
+          "SOL_time_ms": {
+            "XPU-A": 0.62,
+            "H20": 0.82
+          },
+          "description": "(rtp-llm TP1), decode paged attention, heads=64/8 head_dim=128"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 8,
+          "median_us": 15.8,
+          "min_us": 15.2,
+          "max_us": 152.6,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 152.6,
+          "1": 17.1,
+          "2": 24.7,
+          "3": 15.6,
+          "4": 15.7,
+          "5": 15.2,
+          "6": 15.8,
+          "7": 15.5
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self) -> None:\n        super().__init__()\n\n    def forward(self, query: torch.Tensor, k_cache: torch.Tensor, v_cache: torch.Tensor, block_tables: torch.Tensor, seq_lens: torch.Tensor) -> torch.Tensor:\n        (num_seqs, num_query_heads, head_size) = query.shape\n        num_kv_heads = v_cache.shape[1]\n        block_size = v_cache.shape[3]\n        num_queries_per_kv = num_query_heads // num_kv_heads\n        scale = head_size ** (-0.5)\n        k_cache_flat = k_cache.permute(0, 3, 1, 2, 4).contiguous().view(-1, num_kv_heads, head_size)\n        v_cache_flat = v_cache.permute(0, 3, 1, 2).contiguous().view(-1, num_kv_heads, head_size)\n        seq_lens_list = seq_lens.tolist()\n        block_tables_list = block_tables.tolist()\n        output = torch.zeros_like(query)\n        for seq_idx in range(num_seqs):\n            ctx_len = int(seq_lens_list[seq_idx])\n            if ctx_len <= 0:\n                continue\n            blocks = block_tables_list[seq_idx]\n            blocks_t = torch.as_tensor(blocks[:(ctx_len + block_size - 1) // block_size], dtype=torch.long, device=query.device)\n            within = torch.arange(ctx_len, device=query.device, dtype=torch.long)\n            idx = blocks_t[within // block_size] * block_size + within % block_size\n            keys = k_cache_flat.index_select(0, idx).float()\n            values = v_cache_flat.index_select(0, idx).float()\n            if num_queries_per_kv > 1:\n                keys = keys.repeat_interleave(num_queries_per_kv, dim=1)\n                values = values.repeat_interleave(num_queries_per_kv, dim=1)\n            q_seq = query[seq_idx].float().unsqueeze(0).unsqueeze(2)\n            ks = keys.transpose(0, 1).unsqueeze(0)\n            vs = values.transpose(0, 1).unsqueeze(0)\n            os = F.scaled_dot_product_attention(q_seq, ks, vs, is_causal=False)\n            output[seq_idx] = os.squeeze(0).squeeze(1).to(query.dtype)\n        return output\n",
+      "input_code": "import torch\n\ndef _make_inputs(num_seqs: int, ctx_len: int, num_query_heads: int, num_kv_heads: int, head_size: int, block_size: int=16, dtype: str='bf16') -> dict[str, torch.Tensor]:\n    dt = torch.bfloat16 if dtype == 'bf16' else torch.float16\n    max_num_blocks_per_seq = (ctx_len + block_size - 1) // block_size\n    num_blocks = max_num_blocks_per_seq * num_seqs + 16\n    query = torch.randn(num_seqs, num_query_heads, head_size, dtype=dt, device='cuda')\n    x = 16 // dt.itemsize\n    k_cache = torch.randn(num_blocks, num_kv_heads, head_size // x, block_size, x, dtype=dt, device='cuda')\n    v_cache = torch.randn(num_blocks, num_kv_heads, head_size, block_size, dtype=dt, device='cuda')\n    block_tables = torch.zeros(num_seqs, max_num_blocks_per_seq, dtype=torch.int32, device='cuda')\n    for i in range(num_seqs):\n        for j in range(max_num_blocks_per_seq):\n            block_tables[i, j] = i * max_num_blocks_per_seq + j\n    seq_lens = torch.full((num_seqs,), ctx_len, dtype=torch.int32, device='cuda')\n    return {'query': query, 'k_cache': k_cache, 'v_cache': v_cache, 'block_tables': block_tables, 'seq_lens': seq_lens}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM), decode paged attention, heads=16/16 head_dim=128 ctx_len=64",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 256,
+            "ctx_len": 64,
+            "num_query_heads": 16,
+            "num_kv_heads": 16,
+            "head_size": 128,
+            "block_size": 16,
+            "dtype": "bf16"
+          },
+          "W_flops": 134250496,
+          "Q_bytes": 138417152,
+          "ai": 1.0,
+          "SOL_time_ms": {
+            "XPU-A": 26.12,
+            "H20": 34.6
+          },
+          "prod_us": {
+            "XPU-A": 152.6
+          }
+        },
+        "1": {
+          "description": "(SGLang TP1), decode paged attention, heads=16/2 head_dim=256",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "num_query_heads": 16,
+            "num_kv_heads": 2,
+            "head_size": 256,
+            "block_size": 16,
+            "ctx_len": 128,
+            "dtype": "bf16"
+          },
+          "W_flops": 2097408,
+          "Q_bytes": 802852,
+          "ai": 2.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.15,
+            "H20": 0.2
+          },
+          "prod_us": {
+            "XPU-A": 17.1
+          }
+        },
+        "2": {
+          "description": "(vLLM), decode paged attention, heads=3/3 head_dim=128 ctx_len=64",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 128,
+            "ctx_len": 64,
+            "num_query_heads": 3,
+            "num_kv_heads": 3,
+            "head_size": 128,
+            "block_size": 16,
+            "dtype": "bf16"
+          },
+          "W_flops": 12599296,
+          "Q_bytes": 13175296,
+          "ai": 1.0,
+          "SOL_time_ms": {
+            "XPU-A": 2.49,
+            "H20": 3.29
+          },
+          "prod_us": {
+            "XPU-A": 24.7
+          }
+        },
+        "3": {
+          "description": "(rtp-llm TP1), decode paged attention, heads=32/4 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 4,
+            "ctx_len": 128,
+            "num_query_heads": 32,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "block_size": 16,
+            "dtype": "bf16"
+          },
+          "W_flops": 8389632,
+          "Q_bytes": 1638544,
+          "ai": 5.1,
+          "SOL_time_ms": {
+            "XPU-A": 0.31,
+            "H20": 0.41
+          },
+          "prod_us": {
+            "XPU-A": 15.6
+          }
+        },
+        "4": {
+          "description": "(rtp-llm TP1), decode paged attention, heads=32/8 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 4,
+            "ctx_len": 128,
+            "num_query_heads": 32,
+            "num_kv_heads": 8,
+            "head_size": 128,
+            "block_size": 16,
+            "dtype": "fp16"
+          },
+          "W_flops": 8389632,
+          "Q_bytes": 3211408,
+          "ai": 2.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.61,
+            "H20": 0.8
+          },
+          "prod_us": {
+            "XPU-A": 15.7
+          }
+        },
+        "5": {
+          "description": "(SGLang TP8), decode paged attention, heads=4/1 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 1,
+            "num_query_heads": 4,
+            "num_kv_heads": 1,
+            "head_size": 128,
+            "block_size": 16,
+            "ctx_len": 128,
+            "dtype": "bf16"
+          },
+          "W_flops": 262400,
+          "Q_bytes": 198692,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.04,
+            "H20": 0.05
+          },
+          "prod_us": {
+            "XPU-A": 15.2
+          }
+        },
+        "6": {
+          "description": "(rtp-llm TP1), decode paged attention, heads=40/8 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 4,
+            "ctx_len": 128,
+            "num_query_heads": 40,
+            "num_kv_heads": 8,
+            "head_size": 128,
+            "block_size": 16,
+            "dtype": "fp16"
+          },
+          "W_flops": 10486784,
+          "Q_bytes": 3227792,
+          "ai": 3.2,
+          "SOL_time_ms": {
+            "XPU-A": 0.61,
+            "H20": 0.81
+          },
+          "prod_us": {
+            "XPU-A": 15.8
+          }
+        },
+        "7": {
+          "description": "(rtp-llm TP1), decode paged attention, heads=64/8 head_dim=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_seqs": 4,
+            "ctx_len": 128,
+            "num_query_heads": 64,
+            "num_kv_heads": 8,
+            "head_size": 128,
+            "block_size": 16,
+            "dtype": "fp16"
+          },
+          "W_flops": 16778240,
+          "Q_bytes": 3276944,
+          "ai": 5.1,
+          "SOL_time_ms": {
+            "XPU-A": 0.62,
+            "H20": 0.82
+          },
+          "prod_us": {
+            "XPU-A": 15.5
+          }
+        }
+      }
+    },
+    {
+      "name": "reshape_and_cache",
+      "id": "atrex_026",
+      "dtype": "bf16",
+      "framework": "vllm",
+      "symbol": "reshape_and_cache_flash",
+      "module": "vllm._C_cache_ops.reshape_and_cache_flash",
+      "phase": "prefill/decode",
+      "shapes": 8,
+      "importance": 0.043524,
+      "roofline": {
+        "median_ai": 0.0,
+        "regime": "indexing/structural",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 0,
+          "Q_bytes": 67592,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.02
+          },
+          "description": "(vLLM TP1), KV cache reshape_and_cache, shape=(1,4,128)"
+        },
+        "1": {
+          "W_flops": 0,
+          "Q_bytes": 885888,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.17,
+            "H20": 0.22
+          },
+          "description": "(vLLM TP1), KV cache reshape_and_cache, shape=(144,2,256)"
+        },
+        "2": {
+          "W_flops": 0,
+          "Q_bytes": 6227904,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 1.18,
+            "H20": 1.56
+          },
+          "description": "(vLLM TP4), KV cache reshape_and_cache, shape=(248,16,128)"
+        },
+        "3": {
+          "W_flops": 0,
+          "Q_bytes": 12914752,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 2.44,
+            "H20": 3.23
+          },
+          "description": "(vLLM TP4), KV cache reshape_and_cache, shape=(520,16,128)"
+        },
+        "4": {
+          "W_flops": 0,
+          "Q_bytes": 25100216,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 4.74,
+            "H20": 6.28
+          },
+          "description": "(vLLM TP4), KV cache reshape_and_cache, shape=(1015,16,128)"
+        },
+        "5": {
+          "W_flops": 0,
+          "Q_bytes": 50315232,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 9.49,
+            "H20": 12.58
+          },
+          "description": "(vLLM TP4), KV cache reshape_and_cache, shape=(2044,16,128)"
+        },
+        "6": {
+          "W_flops": 0,
+          "Q_bytes": 25288800,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 4.77,
+            "H20": 6.32
+          },
+          "description": "(vLLM TP1), KV cache reshape_and_cache, shape=(4108,4,128)"
+        },
+        "7": {
+          "W_flops": 0,
+          "Q_bytes": 50397184,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 9.51,
+            "H20": 12.6
+          },
+          "description": "(vLLM TP1), KV cache reshape_and_cache, shape=(8192,4,128)"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 8,
+          "median_us": 21.2,
+          "min_us": 7.5,
+          "max_us": 60.3,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 7.5,
+          "1": 7.7,
+          "2": 9.8,
+          "3": 14.2,
+          "4": 21.2,
+          "5": 29.2,
+          "6": 33.7,
+          "7": 60.3
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self) -> None:\n        super().__init__()\n\n    def forward(self, key: torch.Tensor, value: torch.Tensor, key_cache: torch.Tensor, value_cache: torch.Tensor, slot_mapping: torch.Tensor) -> dict[str, torch.Tensor]:\n        key_out = key_cache.clone()\n        value_out = value_cache.clone()\n        valid = slot_mapping >= 0\n        slots = slot_mapping[valid].long()\n        key_out.view(-1, key.shape[1], key.shape[2])[slots] = key[valid].to(key_out.dtype)\n        value_out.view(-1, value.shape[1], value.shape[2])[slots] = value[valid].to(value_out.dtype)\n        return {'key_cache': key_out, 'value_cache': value_out}\n",
+      "input_code": "import torch\n\ndef _make_inputs(shape: list[int], block_size: int=16) -> dict[str, torch.Tensor]:\n    (num_tokens, num_heads, head_size) = (int(dim) for dim in shape)\n    block_size = int(block_size)\n    num_blocks = (num_tokens + block_size - 1) // block_size\n    key = torch.randn((num_tokens, num_heads, head_size), dtype=torch.bfloat16, device='cuda')\n    value = torch.randn((num_tokens, num_heads, head_size), dtype=torch.bfloat16, device='cuda')\n    key_cache = torch.zeros((num_blocks, block_size, num_heads, head_size), dtype=torch.bfloat16, device='cuda')\n    value_cache = torch.zeros_like(key_cache)\n    slot_mapping = torch.arange(num_tokens, dtype=torch.long, device='cuda')\n    return {'key': key, 'value': value, 'key_cache': key_cache, 'value_cache': value_cache, 'slot_mapping': slot_mapping}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM TP1), KV cache reshape_and_cache, shape=(1,4,128)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1,
+              4,
+              128
+            ],
+            "block_size": 16
+          },
+          "W_flops": 0,
+          "Q_bytes": 67592,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.02
+          },
+          "prod_us": {
+            "XPU-A": 7.5
+          }
+        },
+        "1": {
+          "description": "(vLLM TP1), KV cache reshape_and_cache, shape=(144,2,256)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              144,
+              2,
+              256
+            ],
+            "block_size": 16
+          },
+          "W_flops": 0,
+          "Q_bytes": 885888,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.17,
+            "H20": 0.22
+          },
+          "prod_us": {
+            "XPU-A": 7.7
+          }
+        },
+        "2": {
+          "description": "(vLLM TP4), KV cache reshape_and_cache, shape=(248,16,128)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              248,
+              16,
+              128
+            ],
+            "block_size": 16
+          },
+          "W_flops": 0,
+          "Q_bytes": 6227904,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 1.18,
+            "H20": 1.56
+          },
+          "prod_us": {
+            "XPU-A": 9.8
+          }
+        },
+        "3": {
+          "description": "(vLLM TP4), KV cache reshape_and_cache, shape=(520,16,128)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              520,
+              16,
+              128
+            ],
+            "block_size": 16
+          },
+          "W_flops": 0,
+          "Q_bytes": 12914752,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 2.44,
+            "H20": 3.23
+          },
+          "prod_us": {
+            "XPU-A": 14.2
+          }
+        },
+        "4": {
+          "description": "(vLLM TP4), KV cache reshape_and_cache, shape=(1015,16,128)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1015,
+              16,
+              128
+            ],
+            "block_size": 16
+          },
+          "W_flops": 0,
+          "Q_bytes": 25100216,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 4.74,
+            "H20": 6.28
+          },
+          "prod_us": {
+            "XPU-A": 21.2
+          }
+        },
+        "5": {
+          "description": "(vLLM TP4), KV cache reshape_and_cache, shape=(2044,16,128)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              2044,
+              16,
+              128
+            ],
+            "block_size": 16
+          },
+          "W_flops": 0,
+          "Q_bytes": 50315232,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 9.49,
+            "H20": 12.58
+          },
+          "prod_us": {
+            "XPU-A": 29.2
+          }
+        },
+        "6": {
+          "description": "(vLLM TP1), KV cache reshape_and_cache, shape=(4108,4,128)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              4108,
+              4,
+              128
+            ],
+            "block_size": 16
+          },
+          "W_flops": 0,
+          "Q_bytes": 25288800,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 4.77,
+            "H20": 6.32
+          },
+          "prod_us": {
+            "XPU-A": 33.7
+          }
+        },
+        "7": {
+          "description": "(vLLM TP1), KV cache reshape_and_cache, shape=(8192,4,128)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              8192,
+              4,
+              128
+            ],
+            "block_size": 16
+          },
+          "W_flops": 0,
+          "Q_bytes": 50397184,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 9.51,
+            "H20": 12.6
+          },
+          "prod_us": {
+            "XPU-A": 60.3
+          }
+        }
+      }
+    },
+    {
+      "name": "topk_filter",
+      "id": "atrex_029",
+      "dtype": "fp32",
+      "framework": "vllm",
+      "symbol": "void flashinfer::sampling::TopKMaskLogitsKernel<1024u, (cub::CUB_200700_900_NS::BlockReduceAlgorithm)2, 4u, float, int>(float*, float*, int*, unsigned int, unsigned int)",
+      "module": "Sampler.forward",
+      "phase": "decode",
+      "shapes": 8,
+      "importance": 0.035326,
+      "roofline": {
+        "median_ai": 0.0,
+        "regime": "indexing/structural",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 0,
+          "Q_bytes": 1215488,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.23,
+            "H20": 0.3
+          },
+          "description": "(vLLM), top-k logit filter, shape=(1,151936)"
+        },
+        "1": {
+          "W_flops": 0,
+          "Q_bytes": 1216512,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.23,
+            "H20": 0.3
+          },
+          "description": "(vLLM), top-k logit filter, shape=(1,152064)"
+        },
+        "2": {
+          "W_flops": 0,
+          "Q_bytes": 15106048,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 2.85,
+            "H20": 3.78
+          },
+          "description": "(vLLM), top-k logit filter, shape=(922,2048)"
+        },
+        "3": {
+          "W_flops": 0,
+          "Q_bytes": 96048,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.02,
+            "H20": 0.02
+          },
+          "description": "(SGLang), top-k logit filter, shape=(3,4002)"
+        },
+        "4": {
+          "W_flops": 0,
+          "Q_bytes": 134283264,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 25.34,
+            "H20": 33.57
+          },
+          "description": "(SGLang), top-k logit filter, shape=(4098,4096)"
+        },
+        "5": {
+          "W_flops": 0,
+          "Q_bytes": 268009472,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 50.57,
+            "H20": 67.0
+          },
+          "description": "(SGLang), top-k logit filter, shape=(8179,4096)"
+        },
+        "6": {
+          "W_flops": 0,
+          "Q_bytes": 504004608,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 95.1,
+            "H20": 126.0
+          },
+          "description": "(SGLang), top-k logit filter, shape=(15381,4096)"
+        },
+        "7": {
+          "W_flops": 0,
+          "Q_bytes": 101160,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.02,
+            "H20": 0.03
+          },
+          "description": "(SGLang), top-k logit filter, shape=(3,4215)"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 8,
+          "median_us": 328.6,
+          "min_us": 30.7,
+          "max_us": 2932.6,
+          "framework": "sglang"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 299.7,
+          "1": 328.6,
+          "2": 187.4,
+          "3": 31.3,
+          "4": 805.1,
+          "5": 2010.0,
+          "6": 2932.6,
+          "7": 30.7
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self, top_k: int=50) -> None:\n        super().__init__()\n        self.top_k = top_k\n\n    def forward(self, logits: torch.Tensor) -> torch.Tensor:\n        top_k = min(self.top_k, logits.shape[-1])\n        threshold = torch.topk(logits, top_k, dim=-1).values[..., -1:]\n        return logits.masked_fill(logits < threshold, float('-inf'))\n",
+      "input_code": "import torch\n\n\ndef _make_inputs(seq_len: int, hidden_size: int) -> dict[str, torch.Tensor]:\n    logits = torch.randn(seq_len, hidden_size, dtype=torch.float32, device='cuda')\n    return {'logits': logits}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM), top-k logit filter, shape=(1,151936)",
+          "init_kwargs": {
+            "top_k": 50
+          },
+          "input_kwargs": {
+            "seq_len": 1,
+            "hidden_size": 151936
+          },
+          "W_flops": 0,
+          "Q_bytes": 1215488,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.23,
+            "H20": 0.3
+          },
+          "prod_us": {
+            "XPU-A": 299.7
+          }
+        },
+        "1": {
+          "description": "(vLLM), top-k logit filter, shape=(1,152064)",
+          "init_kwargs": {
+            "top_k": 50
+          },
+          "input_kwargs": {
+            "seq_len": 1,
+            "hidden_size": 152064
+          },
+          "W_flops": 0,
+          "Q_bytes": 1216512,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.23,
+            "H20": 0.3
+          },
+          "prod_us": {
+            "XPU-A": 328.6
+          }
+        },
+        "2": {
+          "description": "(vLLM), top-k logit filter, shape=(922,2048)",
+          "init_kwargs": {},
+          "input_kwargs": {
+            "seq_len": 922,
+            "hidden_size": 2048
+          },
+          "W_flops": 0,
+          "Q_bytes": 15106048,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 2.85,
+            "H20": 3.78
+          },
+          "prod_us": {
+            "XPU-A": 187.4
+          }
+        },
+        "3": {
+          "description": "(SGLang), top-k logit filter, shape=(3,4002)",
+          "init_kwargs": {},
+          "input_kwargs": {
+            "seq_len": 3,
+            "hidden_size": 4002
+          },
+          "W_flops": 0,
+          "Q_bytes": 96048,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.02,
+            "H20": 0.02
+          },
+          "prod_us": {
+            "XPU-A": 31.3
+          }
+        },
+        "4": {
+          "description": "(SGLang), top-k logit filter, shape=(4098,4096)",
+          "init_kwargs": {},
+          "input_kwargs": {
+            "seq_len": 4098,
+            "hidden_size": 4096
+          },
+          "W_flops": 0,
+          "Q_bytes": 134283264,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 25.34,
+            "H20": 33.57
+          },
+          "prod_us": {
+            "XPU-A": 805.1
+          }
+        },
+        "5": {
+          "description": "(SGLang), top-k logit filter, shape=(8179,4096)",
+          "init_kwargs": {},
+          "input_kwargs": {
+            "seq_len": 8179,
+            "hidden_size": 4096
+          },
+          "W_flops": 0,
+          "Q_bytes": 268009472,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 50.57,
+            "H20": 67.0
+          },
+          "prod_us": {
+            "XPU-A": 2010.0
+          }
+        },
+        "6": {
+          "description": "(SGLang), top-k logit filter, shape=(15381,4096)",
+          "init_kwargs": {},
+          "input_kwargs": {
+            "seq_len": 15381,
+            "hidden_size": 4096
+          },
+          "W_flops": 0,
+          "Q_bytes": 504004608,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 95.1,
+            "H20": 126.0
+          },
+          "prod_us": {
+            "XPU-A": 2932.6
+          }
+        },
+        "7": {
+          "description": "(SGLang), top-k logit filter, shape=(3,4215)",
+          "init_kwargs": {},
+          "input_kwargs": {
+            "seq_len": 3,
+            "hidden_size": 4215
+          },
+          "W_flops": 0,
+          "Q_bytes": 101160,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.02,
+            "H20": 0.03
+          },
+          "prod_us": {
+            "XPU-A": 30.7
+          }
+        }
+      }
+    },
+    {
+      "name": "gated_delta_rule_update",
+      "id": "atrex_013",
+      "dtype": "bf16",
+      "framework": "sglang",
+      "symbol": "fused_sigmoid_gating_delta_rule_update",
+      "module": "sglang.srt.layers.attention.fla.fused_sigmoid_gating_recurrent",
+      "phase": "decode",
+      "shapes": 17,
+      "importance": 0.034959,
+      "roofline": {
+        "median_ai": 89.6,
+        "regime": "compute-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 3682368,
+          "Q_bytes": 8413508,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 1.59,
+            "H20": 2.1
+          },
+          "description": "(SGLang TP1), gated delta rule update, tokens=1 heads=16/32 dim=128/128"
+        },
+        "1": {
+          "W_flops": 471343104,
+          "Q_bytes": 11550916,
+          "ai": 40.8,
+          "SOL_time_ms": {
+            "XPU-A": 2.18,
+            "H20": 3.18
+          },
+          "description": "(vLLM TP1), gated delta rule update, tokens=128 heads=16/32 dim=128/128"
+        },
+        "2": {
+          "W_flops": 950050944,
+          "Q_bytes": 14762436,
+          "ai": 64.4,
+          "SOL_time_ms": {
+            "XPU-A": 4.08,
+            "H20": 6.42
+          },
+          "description": "(vLLM TP1), gated delta rule update, tokens=258 heads=16/32 dim=128/128"
+        },
+        "3": {
+          "W_flops": 2003208192,
+          "Q_bytes": 21827780,
+          "ai": 91.8,
+          "SOL_time_ms": {
+            "XPU-A": 8.61,
+            "H20": 13.54
+          },
+          "description": "(vLLM TP1), gated delta rule update, tokens=544 heads=16/32 dim=128/128"
+        },
+        "4": {
+          "W_flops": 3803886144,
+          "Q_bytes": 33908036,
+          "ai": 112.2,
+          "SOL_time_ms": {
+            "XPU-A": 16.35,
+            "H20": 25.7
+          },
+          "description": "(vLLM TP1), gated delta rule update, tokens=1033 heads=16/32 dim=128/128"
+        },
+        "5": {
+          "W_flops": 7552536768,
+          "Q_bytes": 59056708,
+          "ai": 127.9,
+          "SOL_time_ms": {
+            "XPU-A": 32.46,
+            "H20": 51.03
+          },
+          "description": "(vLLM TP1), gated delta rule update, tokens=2051 heads=16/32 dim=128/128"
+        },
+        "6": {
+          "W_flops": 15171356160,
+          "Q_bytes": 110169284,
+          "ai": 137.7,
+          "SOL_time_ms": {
+            "XPU-A": 65.21,
+            "H20": 102.51
+          },
+          "description": "(vLLM TP1), gated delta rule update, tokens=4120 heads=16/32 dim=128/128"
+        },
+        "7": {
+          "W_flops": 30165958656,
+          "Q_bytes": 210763972,
+          "ai": 143.1,
+          "SOL_time_ms": {
+            "XPU-A": 129.66,
+            "H20": 203.82
+          },
+          "description": "(vLLM TP1), gated delta rule update, tokens=8192 heads=16/32 dim=128/128"
+        },
+        "8": {
+          "W_flops": 920592,
+          "Q_bytes": 2103380,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 0.4,
+            "H20": 0.53
+          },
+          "description": "(vLLM TP4), gated delta rule update, tokens=1 heads=4/8 dim=128/128"
+        },
+        "9": {
+          "W_flops": 1841184,
+          "Q_bytes": 4206756,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 0.79,
+            "H20": 1.05
+          },
+          "description": "(SGLang TP8), gated delta rule update, tokens=1 heads=8/16 dim=128/128"
+        },
+        "10": {
+          "W_flops": 237512736,
+          "Q_bytes": 5787812,
+          "ai": 41.0,
+          "SOL_time_ms": {
+            "XPU-A": 1.09,
+            "H20": 1.6
+          },
+          "description": "(SGLang TP8), gated delta rule update, tokens=129 heads=8/16 dim=128/128"
+        },
+        "12": {
+          "W_flops": 478707840,
+          "Q_bytes": 11600324,
+          "ai": 41.3,
+          "SOL_time_ms": {
+            "XPU-A": 2.19,
+            "H20": 3.23
+          },
+          "description": "(SGLang), gated delta rule update, tokens=130 heads=16/32 dim=128/128"
+        },
+        "13": {
+          "W_flops": 942686208,
+          "Q_bytes": 14713028,
+          "ai": 64.1,
+          "SOL_time_ms": {
+            "XPU-A": 4.05,
+            "H20": 6.37
+          },
+          "description": "(vLLM), gated delta rule update, tokens=256 heads=16/32 dim=128/128"
+        },
+        "14": {
+          "W_flops": 1885372416,
+          "Q_bytes": 21037252,
+          "ai": 89.6,
+          "SOL_time_ms": {
+            "XPU-A": 8.1,
+            "H20": 12.74
+          },
+          "description": "(SGLang), gated delta rule update, tokens=512 heads=16/32 dim=128/128"
+        },
+        "15": {
+          "W_flops": 3789156672,
+          "Q_bytes": 33809220,
+          "ai": 112.1,
+          "SOL_time_ms": {
+            "XPU-A": 16.29,
+            "H20": 25.6
+          },
+          "description": "(SGLang), gated delta rule update, tokens=1029 heads=16/32 dim=128/128"
+        },
+        "16": {
+          "W_flops": 6742415808,
+          "Q_bytes": 53621828,
+          "ai": 125.7,
+          "SOL_time_ms": {
+            "XPU-A": 28.98,
+            "H20": 45.56
+          },
+          "description": "(SGLang), gated delta rule update, tokens=1831 heads=16/32 dim=128/128"
+        },
+        "17": {
+          "W_flops": 11971378368,
+          "Q_bytes": 88701508,
+          "ai": 135.0,
+          "SOL_time_ms": {
+            "XPU-A": 51.46,
+            "H20": 80.89
+          },
+          "description": "(SGLang), gated delta rule update, tokens=3251 heads=16/32 dim=128/128"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 17,
+          "median_us": 1143.6,
+          "min_us": 8.7,
+          "max_us": 20104.8,
+          "framework": "sglang"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 9.6,
+          "1": 295.6,
+          "2": 584.8,
+          "3": 1226.6,
+          "4": 2312.7,
+          "5": 4635.1,
+          "6": 9673.9,
+          "7": 20104.8,
+          "8": 8.9,
+          "9": 8.7,
+          "10": 289.0,
+          "12": 295.6,
+          "13": 574.6,
+          "14": 1143.6,
+          "15": 2288.6,
+          "16": 4065.1,
+          "17": 7234.1
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self, softplus_beta: float=1.0, softplus_threshold: float=20.0, scale: float | None=None, use_qk_l2norm: bool=True) -> None:\n        super().__init__()\n        self.softplus_beta = float(softplus_beta)\n        self.softplus_threshold = float(softplus_threshold)\n        self.scale = scale\n        self.use_qk_l2norm = bool(use_qk_l2norm)\n\n    def forward(self, A_log: torch.Tensor, a: torch.Tensor, dt_bias: torch.Tensor, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, b: torch.Tensor, initial_state: torch.Tensor, initial_state_indices: torch.Tensor) -> dict[str, torch.Tensor]:\n        (batch, tokens, num_q_heads, key_dim) = q.shape\n        (num_v_heads, value_dim) = (v.shape[2], v.shape[3])\n        heads_per_q = max(num_v_heads // num_q_heads, 1)\n        scale = self.scale if self.scale is not None else key_dim ** (-0.5)\n        hv_to_hq = torch.tensor([min(hv // heads_per_q, num_q_heads - 1) for hv in range(num_v_heads)], dtype=torch.long, device=q.device)\n        state = initial_state.float().clone()\n        idx_list = initial_state_indices.tolist()\n        state_indices = torch.tensor(idx_list, dtype=torch.long, device=q.device)\n        h = state.index_select(0, state_indices).clone()\n        BH = batch * num_v_heads\n        h_flat = h.reshape(BH, key_dim, value_dim)\n        A_log_v = A_log.float()\n        dt_bias_v = dt_bias.float()\n        A_log_bh = A_log_v.unsqueeze(0).expand(batch, num_v_heads).reshape(BH)\n        dt_bias_bh = dt_bias_v.unsqueeze(0).expand(batch, num_v_heads).reshape(BH)\n        q_h = q.index_select(2, hv_to_hq).float()\n        k_h = k.index_select(2, hv_to_hq).float()\n        v_h = v.float()\n        a_h = a.float()\n        b_h = b.float()\n        gate_all = F.softplus(a_h + dt_bias_v.unsqueeze(0).unsqueeze(0), beta=self.softplus_beta, threshold=self.softplus_threshold)\n        gate_all = gate_all * (-torch.exp(A_log_v).unsqueeze(0).unsqueeze(0))\n        beta_all = torch.sigmoid(b_h)\n        out = torch.empty_like(v)\n        for t in range(tokens):\n            q_t = q_h[:, t].reshape(BH, key_dim)\n            k_t = k_h[:, t].reshape(BH, key_dim)\n            v_t = v_h[:, t].reshape(BH, value_dim)\n            if self.use_qk_l2norm:\n                q_t = F.normalize(q_t, p=2.0, dim=-1, eps=1e-06)\n                k_t = F.normalize(k_t, p=2.0, dim=-1, eps=1e-06)\n            g = gate_all[:, t].reshape(BH)\n            beta = beta_all[:, t].reshape(BH)\n            h_flat = h_flat * torch.exp(g).view(BH, 1, 1)\n            hk = (h_flat * k_t.unsqueeze(-1)).sum(dim=1)\n            v_new = (v_t - hk) * beta.unsqueeze(-1)\n            h_flat = h_flat + k_t.unsqueeze(-1) * v_new.unsqueeze(-2)\n            q_scaled = q_t * scale\n            out_t = (h_flat * q_scaled.unsqueeze(-1)).sum(dim=1)\n            out[:, t] = out_t.reshape(batch, num_v_heads, value_dim).to(v.dtype)\n        final_h = h_flat.reshape(batch, num_v_heads, key_dim, value_dim)\n        state.index_copy_(0, state_indices, final_h)\n        return {'out': out, 'final_state': state.to(initial_state.dtype)}\n",
+      "input_code": "import torch\n\ndef _make_inputs(batch_size: int, token_count: int, num_q_heads: int, num_v_heads: int, key_dim: int, value_dim: int, state_count: int) -> dict[str, torch.Tensor]:\n    A_log = torch.randn(num_v_heads, dtype=torch.float32, device='cuda') * 0.02\n    a = torch.randn(batch_size, token_count, num_v_heads, dtype=torch.bfloat16, device='cuda') * 0.02\n    dt_bias = torch.randn(num_v_heads, dtype=torch.bfloat16, device='cuda') * 0.02\n    q = torch.randn(batch_size, token_count, num_q_heads, key_dim, dtype=torch.bfloat16, device='cuda') * 0.02\n    k = torch.randn_like(q)\n    v = torch.randn(batch_size, token_count, num_v_heads, value_dim, dtype=torch.bfloat16, device='cuda') * 0.02\n    b = torch.randn_like(a)\n    initial_state = torch.randn(state_count, num_v_heads, key_dim, value_dim, dtype=torch.float32, device='cuda') * 0.02\n    initial_state_indices = torch.arange(batch_size, dtype=torch.int32, device='cuda') % state_count\n    return {'A_log': A_log, 'a': a, 'dt_bias': dt_bias, 'q': q, 'k': k, 'v': v, 'b': b, 'initial_state': initial_state, 'initial_state_indices': initial_state_indices}\n",
+      "shape_details": {
+        "0": {
+          "description": "(SGLang TP1), gated delta rule update, tokens=1 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "num_v_heads": 32,
+            "state_count": 2,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 3682368,
+          "Q_bytes": 8413508,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 1.59,
+            "H20": 2.1
+          },
+          "prod_us": {
+            "XPU-A": 9.6
+          }
+        },
+        "1": {
+          "description": "(vLLM TP1), gated delta rule update, tokens=128 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "token_count": 128,
+            "num_v_heads": 32,
+            "state_count": 2,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 471343104,
+          "Q_bytes": 11550916,
+          "ai": 40.8,
+          "SOL_time_ms": {
+            "XPU-A": 2.18,
+            "H20": 3.18
+          },
+          "prod_us": {
+            "XPU-A": 295.6
+          }
+        },
+        "2": {
+          "description": "(vLLM TP1), gated delta rule update, tokens=258 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "token_count": 258,
+            "num_v_heads": 32,
+            "state_count": 2,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 950050944,
+          "Q_bytes": 14762436,
+          "ai": 64.4,
+          "SOL_time_ms": {
+            "XPU-A": 4.08,
+            "H20": 6.42
+          },
+          "prod_us": {
+            "XPU-A": 584.8
+          }
+        },
+        "3": {
+          "description": "(vLLM TP1), gated delta rule update, tokens=544 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "token_count": 544,
+            "num_v_heads": 32,
+            "state_count": 2,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 2003208192,
+          "Q_bytes": 21827780,
+          "ai": 91.8,
+          "SOL_time_ms": {
+            "XPU-A": 8.61,
+            "H20": 13.54
+          },
+          "prod_us": {
+            "XPU-A": 1226.6
+          }
+        },
+        "4": {
+          "description": "(vLLM TP1), gated delta rule update, tokens=1033 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "token_count": 1033,
+            "num_v_heads": 32,
+            "state_count": 2,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 3803886144,
+          "Q_bytes": 33908036,
+          "ai": 112.2,
+          "SOL_time_ms": {
+            "XPU-A": 16.35,
+            "H20": 25.7
+          },
+          "prod_us": {
+            "XPU-A": 2312.7
+          }
+        },
+        "5": {
+          "description": "(vLLM TP1), gated delta rule update, tokens=2051 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "token_count": 2051,
+            "num_v_heads": 32,
+            "state_count": 2,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 7552536768,
+          "Q_bytes": 59056708,
+          "ai": 127.9,
+          "SOL_time_ms": {
+            "XPU-A": 32.46,
+            "H20": 51.03
+          },
+          "prod_us": {
+            "XPU-A": 4635.1
+          }
+        },
+        "6": {
+          "description": "(vLLM TP1), gated delta rule update, tokens=4120 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "token_count": 4120,
+            "num_v_heads": 32,
+            "state_count": 2,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 15171356160,
+          "Q_bytes": 110169284,
+          "ai": 137.7,
+          "SOL_time_ms": {
+            "XPU-A": 65.21,
+            "H20": 102.51
+          },
+          "prod_us": {
+            "XPU-A": 9673.9
+          }
+        },
+        "7": {
+          "description": "(vLLM TP1), gated delta rule update, tokens=8192 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "token_count": 8192,
+            "num_v_heads": 32,
+            "state_count": 2,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 30165958656,
+          "Q_bytes": 210763972,
+          "ai": 143.1,
+          "SOL_time_ms": {
+            "XPU-A": 129.66,
+            "H20": 203.82
+          },
+          "prod_us": {
+            "XPU-A": 20104.8
+          }
+        },
+        "8": {
+          "description": "(vLLM TP4), gated delta rule update, tokens=1 heads=4/8 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "num_v_heads": 8,
+            "state_count": 2,
+            "value_dim": 128,
+            "num_q_heads": 4,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 920592,
+          "Q_bytes": 2103380,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 0.4,
+            "H20": 0.53
+          },
+          "prod_us": {
+            "XPU-A": 8.9
+          }
+        },
+        "9": {
+          "description": "(SGLang TP8), gated delta rule update, tokens=1 heads=8/16 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "num_v_heads": 16,
+            "state_count": 2,
+            "value_dim": 128,
+            "num_q_heads": 8,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 1841184,
+          "Q_bytes": 4206756,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 0.79,
+            "H20": 1.05
+          },
+          "prod_us": {
+            "XPU-A": 8.7
+          }
+        },
+        "10": {
+          "description": "(SGLang TP8), gated delta rule update, tokens=129 heads=8/16 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "token_count": 129,
+            "num_v_heads": 16,
+            "state_count": 2,
+            "value_dim": 128,
+            "num_q_heads": 8,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 237512736,
+          "Q_bytes": 5787812,
+          "ai": 41.0,
+          "SOL_time_ms": {
+            "XPU-A": 1.09,
+            "H20": 1.6
+          },
+          "prod_us": {
+            "XPU-A": 289.0
+          }
+        },
+        "12": {
+          "description": "(SGLang), gated delta rule update, tokens=130 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "batch_size": 1,
+            "token_count": 130,
+            "num_q_heads": 16,
+            "num_v_heads": 32,
+            "key_dim": 128,
+            "value_dim": 128,
+            "state_count": 2
+          },
+          "W_flops": 478707840,
+          "Q_bytes": 11600324,
+          "ai": 41.3,
+          "SOL_time_ms": {
+            "XPU-A": 2.19,
+            "H20": 3.23
+          },
+          "prod_us": {
+            "XPU-A": 295.6
+          }
+        },
+        "13": {
+          "description": "(vLLM), gated delta rule update, tokens=256 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "batch_size": 1,
+            "token_count": 256,
+            "num_q_heads": 16,
+            "num_v_heads": 32,
+            "key_dim": 128,
+            "value_dim": 128,
+            "state_count": 2
+          },
+          "W_flops": 942686208,
+          "Q_bytes": 14713028,
+          "ai": 64.1,
+          "SOL_time_ms": {
+            "XPU-A": 4.05,
+            "H20": 6.37
+          },
+          "prod_us": {
+            "XPU-A": 574.6
+          }
+        },
+        "14": {
+          "description": "(SGLang), gated delta rule update, tokens=512 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "batch_size": 1,
+            "token_count": 512,
+            "num_q_heads": 16,
+            "num_v_heads": 32,
+            "key_dim": 128,
+            "value_dim": 128,
+            "state_count": 2
+          },
+          "W_flops": 1885372416,
+          "Q_bytes": 21037252,
+          "ai": 89.6,
+          "SOL_time_ms": {
+            "XPU-A": 8.1,
+            "H20": 12.74
+          },
+          "prod_us": {
+            "XPU-A": 1143.6
+          }
+        },
+        "15": {
+          "description": "(SGLang), gated delta rule update, tokens=1029 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "batch_size": 1,
+            "token_count": 1029,
+            "num_q_heads": 16,
+            "num_v_heads": 32,
+            "key_dim": 128,
+            "value_dim": 128,
+            "state_count": 2
+          },
+          "W_flops": 3789156672,
+          "Q_bytes": 33809220,
+          "ai": 112.1,
+          "SOL_time_ms": {
+            "XPU-A": 16.29,
+            "H20": 25.6
+          },
+          "prod_us": {
+            "XPU-A": 2288.6
+          }
+        },
+        "16": {
+          "description": "(SGLang), gated delta rule update, tokens=1831 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "batch_size": 1,
+            "token_count": 1831,
+            "num_q_heads": 16,
+            "num_v_heads": 32,
+            "key_dim": 128,
+            "value_dim": 128,
+            "state_count": 2
+          },
+          "W_flops": 6742415808,
+          "Q_bytes": 53621828,
+          "ai": 125.7,
+          "SOL_time_ms": {
+            "XPU-A": 28.98,
+            "H20": 45.56
+          },
+          "prod_us": {
+            "XPU-A": 4065.1
+          }
+        },
+        "17": {
+          "description": "(SGLang), gated delta rule update, tokens=3251 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "softplus_beta": 1.0,
+            "softplus_threshold": 20.0,
+            "use_qk_l2norm": true
+          },
+          "input_kwargs": {
+            "batch_size": 1,
+            "token_count": 3251,
+            "num_q_heads": 16,
+            "num_v_heads": 32,
+            "key_dim": 128,
+            "value_dim": 128,
+            "state_count": 2
+          },
+          "W_flops": 11971378368,
+          "Q_bytes": 88701508,
+          "ai": 135.0,
+          "SOL_time_ms": {
+            "XPU-A": 51.46,
+            "H20": 80.89
+          },
+          "prod_us": {
+            "XPU-A": 7234.1
+          }
+        }
+      }
+    },
+    {
+      "name": "fused_qkv_rope",
+      "id": "atrex_011",
+      "dtype": "fp16",
+      "framework": "rtp-llm",
+      "symbol": "add_fusedQKV_bias_transpose_prefill_kernel",
+      "module": "rtp_llm.cpp.kernels.unfused_attention_kernels",
+      "phase": "prefill/decode",
+      "shapes": 6,
+      "importance": 0.033527,
+      "roofline": {
+        "median_ai": 0.7,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 14016,
+          "Q_bytes": 20484,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP1), text decoder fusedQKV+RoPE, heads=32/4 head_dim=128"
+        },
+        "1": {
+          "W_flops": 18624,
+          "Q_bytes": 28676,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP1), text decoder fusedQKV+RoPE, heads=40/8 head_dim=128"
+        },
+        "2": {
+          "W_flops": 27840,
+          "Q_bytes": 40964,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP1), text decoder fusedQKV+RoPE, heads=64/8 head_dim=128"
+        },
+        "3": {
+          "W_flops": 15552,
+          "Q_bytes": 24580,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP1), text decoder fusedQKV+RoPE, heads=32/8 head_dim=128"
+        },
+        "5": {
+          "W_flops": 14016,
+          "Q_bytes": 20484,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP2), text decoder fusedQKV+RoPE, heads=32/4 head_dim=128"
+        },
+        "6": {
+          "W_flops": 18624,
+          "Q_bytes": 28676,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP1), text decoder fusedQKV+RoPE, heads=40/8 head_dim=128"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 6,
+          "median_us": 8.9,
+          "min_us": 8.0,
+          "max_us": 11.1,
+          "framework": "rtp"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 8.0,
+          "1": 9.1,
+          "2": 11.1,
+          "3": 8.9,
+          "5": 8.5,
+          "6": 8.0
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\ndef _rotate_half(x: torch.Tensor) -> torch.Tensor:\n    x1 = x[..., :x.shape[-1] // 2]\n    x2 = x[..., x.shape[-1] // 2:]\n    return torch.cat((-x2, x1), dim=-1)\n\nclass Model(nn.Module):\n\n    def __init__(self, num_heads: int, num_kv_heads: int, head_dim: int, rope_dim: int, rope_base: float=10000.0) -> None:\n        super().__init__()\n        self.num_heads = num_heads\n        self.num_kv_heads = num_kv_heads\n        self.head_dim = head_dim\n        self.rope_dim = rope_dim\n        self.rope_base = rope_base\n\n    def _apply_rope(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:\n        d = self.rope_dim\n        x_rope = x[..., :d]\n        x_pass = x[..., d:]\n        rotated = x_rope.float() * cos + _rotate_half(x_rope.float()) * sin\n        rotated = rotated.to(x.dtype)\n        if d < self.head_dim:\n            return torch.cat([rotated, x_pass], dim=-1)\n        return rotated\n\n    def forward(self, qkv: torch.Tensor, positions: torch.Tensor, qkv_bias: torch.Tensor | None=None) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:\n        n = self.num_heads * self.head_dim\n        kv_n = self.num_kv_heads * self.head_dim\n        if qkv_bias is not None:\n            qkv = qkv + qkv_bias\n        q = qkv[..., :n].reshape(-1, self.num_heads, self.head_dim)\n        k = qkv[..., n:n + kv_n].reshape(-1, self.num_kv_heads, self.head_dim)\n        v = qkv[..., n + kv_n:n + 2 * kv_n].reshape(-1, self.num_kv_heads, self.head_dim)\n        inv_freq = 1.0 / self.rope_base ** (torch.arange(0, self.rope_dim, 2, device=qkv.device, dtype=torch.float32) / self.rope_dim)\n        freqs = positions.unsqueeze(-1).float() * inv_freq.unsqueeze(0)\n        emb = torch.cat((freqs, freqs), dim=-1)\n        cos = emb.cos().unsqueeze(1)\n        sin = emb.sin().unsqueeze(1)\n        q = self._apply_rope(q, cos, sin)\n        k = self._apply_rope(k, cos, sin)\n        return (q, k, v)\n",
+      "input_code": "import torch\n\ndef _make_inputs(total_tokens: int, num_heads: int, num_kv_heads: int, head_dim: int, with_bias: bool=False, dtype: str='bf16') -> dict[str, torch.Tensor]:\n    dt = torch.bfloat16 if dtype == 'bf16' else torch.float16\n    n = num_heads * head_dim\n    kv_n = num_kv_heads * head_dim\n    qkv_dim = n + 2 * kv_n\n    qkv = torch.randn(total_tokens, qkv_dim, dtype=dt, device='cuda')\n    positions = torch.arange(total_tokens, dtype=torch.int32, device='cuda')\n    result: dict[str, torch.Tensor] = {'qkv': qkv, 'positions': positions}\n    if with_bias:\n        result['qkv_bias'] = torch.randn(qkv_dim, dtype=dt, device='cuda') * 0.01\n    return result\n",
+      "shape_details": {
+        "0": {
+          "description": "(rtp-llm TP1), text decoder fusedQKV+RoPE, heads=32/4 head_dim=128",
+          "init_kwargs": {
+            "num_heads": 32,
+            "num_kv_heads": 4,
+            "head_dim": 128,
+            "rope_dim": 128
+          },
+          "input_kwargs": {
+            "total_tokens": 1,
+            "num_heads": 32,
+            "num_kv_heads": 4,
+            "head_dim": 128,
+            "dtype": "bf16"
+          },
+          "W_flops": 14016,
+          "Q_bytes": 20484,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 8.0
+          }
+        },
+        "1": {
+          "description": "(rtp-llm TP1), text decoder fusedQKV+RoPE, heads=40/8 head_dim=128",
+          "init_kwargs": {
+            "num_heads": 40,
+            "num_kv_heads": 8,
+            "head_dim": 128,
+            "rope_dim": 128
+          },
+          "input_kwargs": {
+            "total_tokens": 1,
+            "num_heads": 40,
+            "num_kv_heads": 8,
+            "head_dim": 128,
+            "dtype": "fp16"
+          },
+          "W_flops": 18624,
+          "Q_bytes": 28676,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 9.1
+          }
+        },
+        "2": {
+          "description": "(rtp-llm TP1), text decoder fusedQKV+RoPE, heads=64/8 head_dim=128",
+          "init_kwargs": {
+            "num_heads": 64,
+            "num_kv_heads": 8,
+            "head_dim": 128,
+            "rope_dim": 128
+          },
+          "input_kwargs": {
+            "total_tokens": 1,
+            "num_heads": 64,
+            "num_kv_heads": 8,
+            "head_dim": 128,
+            "dtype": "fp16"
+          },
+          "W_flops": 27840,
+          "Q_bytes": 40964,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 11.1
+          }
+        },
+        "3": {
+          "description": "(rtp-llm TP1), text decoder fusedQKV+RoPE, heads=32/8 head_dim=128",
+          "init_kwargs": {
+            "num_heads": 32,
+            "num_kv_heads": 8,
+            "head_dim": 128,
+            "rope_dim": 128
+          },
+          "input_kwargs": {
+            "total_tokens": 1,
+            "num_heads": 32,
+            "num_kv_heads": 8,
+            "head_dim": 128,
+            "dtype": "fp16"
+          },
+          "W_flops": 15552,
+          "Q_bytes": 24580,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 8.9
+          }
+        },
+        "5": {
+          "description": "(rtp-llm TP2), text decoder fusedQKV+RoPE, heads=32/4 head_dim=128",
+          "init_kwargs": {
+            "num_heads": 32,
+            "num_kv_heads": 4,
+            "head_dim": 128,
+            "rope_dim": 128
+          },
+          "input_kwargs": {
+            "total_tokens": 1,
+            "num_heads": 32,
+            "num_kv_heads": 4,
+            "head_dim": 128,
+            "dtype": "fp16"
+          },
+          "W_flops": 14016,
+          "Q_bytes": 20484,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 8.5
+          }
+        },
+        "6": {
+          "description": "(rtp-llm TP1), text decoder fusedQKV+RoPE, heads=40/8 head_dim=128",
+          "init_kwargs": {
+            "num_heads": 40,
+            "num_kv_heads": 8,
+            "head_dim": 128,
+            "rope_dim": 128
+          },
+          "input_kwargs": {
+            "total_tokens": 1,
+            "num_heads": 40,
+            "num_kv_heads": 8,
+            "head_dim": 128,
+            "dtype": "bf16"
+          },
+          "W_flops": 18624,
+          "Q_bytes": 28676,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 8.0
+          }
+        }
+      }
+    },
+    {
+      "name": "rms_norm",
+      "id": "atrex_027",
+      "dtype": "bf16",
+      "framework": "vllm",
+      "symbol": "rms_norm",
+      "module": "vllm.csrc.layernorm_kernels",
+      "phase": "prefill/decode",
+      "shapes": 56,
+      "importance": 0.027508,
+      "roofline": {
+        "median_ai": 0.8,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 7682500,
+          "Q_bytes": 10242048,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.93,
+            "H20": 2.56
+          },
+          "description": "(vLLM), RMSNorm, tokens=2500 hidden=1024"
+        },
+        "1": {
+          "W_flops": 15266664,
+          "Q_bytes": 20350976,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 3.84,
+            "H20": 5.09
+          },
+          "description": "(vLLM), RMSNorm, tokens=4968 hidden=1024"
+        },
+        "2": {
+          "W_flops": 30730000,
+          "Q_bytes": 40962048,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 7.73,
+            "H20": 10.24
+          },
+          "description": "(vLLM), RMSNorm, tokens=10000 hidden=1024"
+        },
+        "3": {
+          "W_flops": 49782600,
+          "Q_bytes": 66357248,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 12.52,
+            "H20": 16.59
+          },
+          "description": "(vLLM), RMSNorm, tokens=16200 hidden=1024"
+        },
+        "4": {
+          "W_flops": 67913300,
+          "Q_bytes": 90523648,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 17.08,
+            "H20": 22.63
+          },
+          "description": "(vLLM), RMSNorm, tokens=22100 hidden=1024"
+        },
+        "5": {
+          "W_flops": 1244520,
+          "Q_bytes": 1661184,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.31,
+            "H20": 0.42
+          },
+          "description": "(vLLM), RMSNorm, tokens=360 hidden=1152"
+        },
+        "6": {
+          "W_flops": 2489040,
+          "Q_bytes": 3320064,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.63,
+            "H20": 0.83
+          },
+          "description": "(vLLM), RMSNorm, tokens=720 hidden=1152"
+        },
+        "7": {
+          "W_flops": 4148400,
+          "Q_bytes": 5531904,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 1.04,
+            "H20": 1.38
+          },
+          "description": "(vLLM), RMSNorm, tokens=1200 hidden=1152"
+        },
+        "8": {
+          "W_flops": 7315012,
+          "Q_bytes": 9752832,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.84,
+            "H20": 2.44
+          },
+          "description": "(vLLM), RMSNorm, tokens=2116 hidden=1152"
+        },
+        "9": {
+          "W_flops": 13288708,
+          "Q_bytes": 17715456,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 3.34,
+            "H20": 4.43
+          },
+          "description": "(vLLM), RMSNorm, tokens=3844 hidden=1152"
+        },
+        "10": {
+          "W_flops": 28126152,
+          "Q_bytes": 37492992,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 7.07,
+            "H20": 9.37
+          },
+          "description": "(vLLM), RMSNorm, tokens=8136 hidden=1152"
+        },
+        "11": {
+          "W_flops": 51855000,
+          "Q_bytes": 69122304,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 13.04,
+            "H20": 17.28
+          },
+          "description": "(vLLM), RMSNorm, tokens=15000 hidden=1152"
+        },
+        "12": {
+          "W_flops": 84240176,
+          "Q_bytes": 112290048,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 21.19,
+            "H20": 28.07
+          },
+          "description": "(vLLM), RMSNorm, tokens=24368 hidden=1152"
+        },
+        "13": {
+          "W_flops": 169918464,
+          "Q_bytes": 226494720,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 42.73,
+            "H20": 56.62
+          },
+          "description": "(vLLM), RMSNorm, tokens=49152 hidden=1152"
+        },
+        "14": {
+          "W_flops": 226627092,
+          "Q_bytes": 302084352,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 57.0,
+            "H20": 75.52
+          },
+          "description": "(vLLM), RMSNorm, tokens=65556 hidden=1152"
+        },
+        "15": {
+          "W_flops": 1155,
+          "Q_bytes": 1792,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(SGLang), RMSNorm, tokens=3 hidden=128"
+        },
+        "16": {
+          "W_flops": 579040,
+          "Q_bytes": 770304,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.15,
+            "H20": 0.19
+          },
+          "description": "(SGLang), RMSNorm, tokens=1504 hidden=128"
+        },
+        "17": {
+          "W_flops": 788480,
+          "Q_bytes": 1048832,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.2,
+            "H20": 0.26
+          },
+          "description": "(SGLang), RMSNorm, tokens=2048 hidden=128"
+        },
+        "18": {
+          "W_flops": 1576960,
+          "Q_bytes": 2097408,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.4,
+            "H20": 0.52
+          },
+          "description": "(SGLang), RMSNorm, tokens=4096 hidden=128"
+        },
+        "19": {
+          "W_flops": 3153920,
+          "Q_bytes": 4194560,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.79,
+            "H20": 1.05
+          },
+          "description": "(SGLang), RMSNorm, tokens=8192 hidden=128"
+        },
+        "20": {
+          "W_flops": 6307840,
+          "Q_bytes": 8388864,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.58,
+            "H20": 2.1
+          },
+          "description": "(SGLang), RMSNorm, tokens=16384 hidden=128"
+        },
+        "21": {
+          "W_flops": 9449440,
+          "Q_bytes": 12566784,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 2.37,
+            "H20": 3.14
+          },
+          "description": "(SGLang), RMSNorm, tokens=24544 hidden=128"
+        },
+        "22": {
+          "W_flops": 18874240,
+          "Q_bytes": 25100544,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 4.74,
+            "H20": 6.28
+          },
+          "description": "(SGLang), RMSNorm, tokens=49024 hidden=128"
+        },
+        "23": {
+          "W_flops": 25212880,
+          "Q_bytes": 33530112,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 6.33,
+            "H20": 8.38
+          },
+          "description": "(vLLM), RMSNorm, tokens=65488 hidden=128"
+        },
+        "24": {
+          "W_flops": 36941520,
+          "Q_bytes": 49127680,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 9.27,
+            "H20": 12.28
+          },
+          "description": "(vLLM), RMSNorm, tokens=95952 hidden=128"
+        },
+        "25": {
+          "W_flops": 50462720,
+          "Q_bytes": 67109120,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 12.66,
+            "H20": 16.78
+          },
+          "description": "(vLLM), RMSNorm, tokens=131072 hidden=128"
+        },
+        "26": {
+          "W_flops": 95356800,
+          "Q_bytes": 126812416,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 23.93,
+            "H20": 31.7
+          },
+          "description": "(vLLM), RMSNorm, tokens=247680 hidden=128"
+        },
+        "27": {
+          "W_flops": 194766880,
+          "Q_bytes": 259014912,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 48.87,
+            "H20": 64.75
+          },
+          "description": "(SGLang), RMSNorm, tokens=505888 hidden=128"
+        },
+        "28": {
+          "W_flops": 26887,
+          "Q_bytes": 38400,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "description": "(vLLM), RMSNorm, tokens=7 hidden=1280"
+        },
+        "29": {
+          "W_flops": 95072432,
+          "Q_bytes": 126732800,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 23.91,
+            "H20": 31.68
+          },
+          "description": "(rtp-llm), RMSNorm, tokens=24752 hidden=1280"
+        },
+        "30": {
+          "W_flops": 8001224,
+          "Q_bytes": 10669056,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 2.01,
+            "H20": 2.67
+          },
+          "description": "(vLLM), RMSNorm, tokens=1736 hidden=1536"
+        },
+        "31": {
+          "W_flops": 23045000,
+          "Q_bytes": 30723072,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 5.8,
+            "H20": 7.68
+          },
+          "description": "(vLLM), RMSNorm, tokens=5000 hidden=1536"
+        },
+        "32": {
+          "W_flops": 786560,
+          "Q_bytes": 1052672,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.2,
+            "H20": 0.26
+          },
+          "description": "(SGLang), RMSNorm, tokens=128 hidden=2048"
+        },
+        "33": {
+          "W_flops": 1573120,
+          "Q_bytes": 2101248,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.4,
+            "H20": 0.53
+          },
+          "description": "(SGLang), RMSNorm, tokens=256 hidden=2048"
+        },
+        "34": {
+          "W_flops": 3146240,
+          "Q_bytes": 4198400,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.79,
+            "H20": 1.05
+          },
+          "description": "(SGLang), RMSNorm, tokens=512 hidden=2048"
+        },
+        "35": {
+          "W_flops": 6323205,
+          "Q_bytes": 8433664,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 1.59,
+            "H20": 2.11
+          },
+          "description": "(SGLang), RMSNorm, tokens=1029 hidden=2048"
+        },
+        "36": {
+          "W_flops": 12351450,
+          "Q_bytes": 16470016,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.11,
+            "H20": 4.12
+          },
+          "description": "(vLLM TP1), RMSNorm, tokens=2010 hidden=2048"
+        },
+        "37": {
+          "W_flops": 25649230,
+          "Q_bytes": 34197504,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 6.45,
+            "H20": 8.55
+          },
+          "description": "(SGLang), RMSNorm, tokens=4174 hidden=2048"
+        },
+        "38": {
+          "W_flops": 50942050,
+          "Q_bytes": 67915776,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 12.81,
+            "H20": 16.98
+          },
+          "description": "(vLLM), RMSNorm, tokens=8290 hidden=2048"
+        },
+        "39": {
+          "W_flops": 101576850,
+          "Q_bytes": 135417856,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 25.55,
+            "H20": 33.85
+          },
+          "description": "(vLLM), RMSNorm, tokens=16530 hidden=2048"
+        },
+        "40": {
+          "W_flops": 126206010,
+          "Q_bytes": 168251392,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 31.75,
+            "H20": 42.06
+          },
+          "description": "(vLLM), RMSNorm, tokens=20538 hidden=2048"
+        },
+        "41": {
+          "W_flops": 2307,
+          "Q_bytes": 3584,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(SGLang), RMSNorm, tokens=3 hidden=256"
+        },
+        "42": {
+          "W_flops": 12842632,
+          "Q_bytes": 17126400,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.23,
+            "H20": 4.28
+          },
+          "description": "(SGLang), RMSNorm, tokens=1672 hidden=2560"
+        },
+        "43": {
+          "W_flops": 3204394,
+          "Q_bytes": 4279296,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.81,
+            "H20": 1.07
+          },
+          "description": "(vLLM TP1), RMSNorm, tokens=298 hidden=3584"
+        },
+        "44": {
+          "W_flops": 5527042,
+          "Q_bytes": 7375872,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 1.39,
+            "H20": 1.84
+          },
+          "description": "(vLLM TP1), RMSNorm, tokens=514 hidden=3584"
+        },
+        "45": {
+          "W_flops": 11011072,
+          "Q_bytes": 14687232,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 2.77,
+            "H20": 3.67
+          },
+          "description": "(vLLM TP1), RMSNorm, tokens=1024 hidden=3584"
+        },
+        "46": {
+          "W_flops": 4611,
+          "Q_bytes": 7168,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(SGLang), RMSNorm, tokens=3 hidden=512"
+        },
+        "47": {
+          "W_flops": 15361,
+          "Q_bytes": 30720,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP1), RMSNorm, tokens=1 hidden=5120"
+        },
+        "48": {
+          "W_flops": 1139765,
+          "Q_bytes": 1533952,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.29,
+            "H20": 0.38
+          },
+          "description": "(SGLang TP8), RMSNorm, tokens=53 hidden=7168"
+        },
+        "49": {
+          "W_flops": 3032205,
+          "Q_bytes": 4057088,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.77,
+            "H20": 1.01
+          },
+          "description": "(SGLang TP8), RMSNorm, tokens=141 hidden=7168"
+        },
+        "50": {
+          "W_flops": 13591160,
+          "Q_bytes": 18135040,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.42,
+            "H20": 4.53
+          },
+          "description": "(SGLang TP8), RMSNorm, tokens=632 hidden=7168"
+        },
+        "51": {
+          "W_flops": 19720085,
+          "Q_bytes": 26306560,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 4.96,
+            "H20": 6.58
+          },
+          "description": "(SGLang TP8), RMSNorm, tokens=917 hidden=7168"
+        },
+        "52": {
+          "W_flops": 36300440,
+          "Q_bytes": 48412672,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 9.13,
+            "H20": 12.1
+          },
+          "description": "(SGLang/vLLM), RMSNorm, tokens=1688 hidden=7168"
+        },
+        "53": {
+          "W_flops": 81805020,
+          "Q_bytes": 109082624,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 20.58,
+            "H20": 27.27
+          },
+          "description": "(SGLang/vLLM), RMSNorm, tokens=3804 hidden=7168"
+        },
+        "54": {
+          "W_flops": 3784858,
+          "Q_bytes": 5062656,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.96,
+            "H20": 1.27
+          },
+          "description": "(SGLang), RMSNorm, tokens=154 hidden=8192"
+        },
+        "55": {
+          "W_flops": 12534270,
+          "Q_bytes": 16728064,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.16,
+            "H20": 4.18
+          },
+          "description": "(SGLang), RMSNorm, tokens=510 hidden=8192"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 56,
+          "median_us": 14.1,
+          "min_us": 7.4,
+          "max_us": 371.2,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 9.9,
+          "1": 14.1,
+          "2": 22.8,
+          "3": 32.7,
+          "4": 42.1,
+          "5": 7.8,
+          "6": 8.1,
+          "7": 9.2,
+          "8": 12.3,
+          "9": 17.7,
+          "10": 31.1,
+          "11": 52.1,
+          "12": 81.2,
+          "13": 157.4,
+          "14": 208.0,
+          "15": 7.5,
+          "16": 7.7,
+          "17": 7.7,
+          "18": 8.7,
+          "19": 11.8,
+          "20": 18.5,
+          "21": 24.4,
+          "22": 42.0,
+          "23": 53.9,
+          "24": 75.8,
+          "25": 101.1,
+          "26": 190.8,
+          "27": 371.2,
+          "28": 7.5,
+          "29": 82.1,
+          "30": 11.6,
+          "31": 22.1,
+          "32": 7.7,
+          "33": 7.8,
+          "34": 8.2,
+          "35": 9.1,
+          "36": 12.6,
+          "37": 21.0,
+          "38": 34.9,
+          "39": 62.8,
+          "40": 80.5,
+          "41": 7.5,
+          "42": 14.2,
+          "43": 7.9,
+          "44": 8.7,
+          "45": 11.4,
+          "46": 7.4,
+          "47": 7.5,
+          "48": 7.7,
+          "49": 7.9,
+          "50": 12.9,
+          "51": 16.4,
+          "52": 24.9,
+          "53": 46.5,
+          "54": 8.0,
+          "55": 12.4
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self, eps: float=1e-06) -> None:\n        super().__init__()\n        self.eps = float(eps)\n\n    def forward(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:\n        x_f = x.float()\n        variance = x_f.square().mean(dim=-1, keepdim=True)\n        out = x_f * torch.rsqrt(variance + self.eps) * weight.float()\n        return out.to(x.dtype)\n",
+      "input_code": "import torch\n\ndef _make_inputs(token_count: int, hidden_size: int) -> dict[str, torch.Tensor]:\n    x = torch.randn(token_count, hidden_size, dtype=torch.bfloat16, device='cuda') * 0.02\n    weight = torch.randn(hidden_size, dtype=torch.bfloat16, device='cuda') * 0.02 + 1.0\n    return {'x': x, 'weight': weight}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM), RMSNorm, tokens=2500 hidden=1024",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 2500,
+            "hidden_size": 1024
+          },
+          "W_flops": 7682500,
+          "Q_bytes": 10242048,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.93,
+            "H20": 2.56
+          },
+          "prod_us": {
+            "XPU-A": 9.9
+          }
+        },
+        "1": {
+          "description": "(vLLM), RMSNorm, tokens=4968 hidden=1024",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 4968,
+            "hidden_size": 1024
+          },
+          "W_flops": 15266664,
+          "Q_bytes": 20350976,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 3.84,
+            "H20": 5.09
+          },
+          "prod_us": {
+            "XPU-A": 14.1
+          }
+        },
+        "2": {
+          "description": "(vLLM), RMSNorm, tokens=10000 hidden=1024",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 10000,
+            "hidden_size": 1024
+          },
+          "W_flops": 30730000,
+          "Q_bytes": 40962048,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 7.73,
+            "H20": 10.24
+          },
+          "prod_us": {
+            "XPU-A": 22.8
+          }
+        },
+        "3": {
+          "description": "(vLLM), RMSNorm, tokens=16200 hidden=1024",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 16200,
+            "hidden_size": 1024
+          },
+          "W_flops": 49782600,
+          "Q_bytes": 66357248,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 12.52,
+            "H20": 16.59
+          },
+          "prod_us": {
+            "XPU-A": 32.7
+          }
+        },
+        "4": {
+          "description": "(vLLM), RMSNorm, tokens=22100 hidden=1024",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 22100,
+            "hidden_size": 1024
+          },
+          "W_flops": 67913300,
+          "Q_bytes": 90523648,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 17.08,
+            "H20": 22.63
+          },
+          "prod_us": {
+            "XPU-A": 42.1
+          }
+        },
+        "5": {
+          "description": "(vLLM), RMSNorm, tokens=360 hidden=1152",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 360,
+            "hidden_size": 1152
+          },
+          "W_flops": 1244520,
+          "Q_bytes": 1661184,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.31,
+            "H20": 0.42
+          },
+          "prod_us": {
+            "XPU-A": 7.8
+          }
+        },
+        "6": {
+          "description": "(vLLM), RMSNorm, tokens=720 hidden=1152",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 720,
+            "hidden_size": 1152
+          },
+          "W_flops": 2489040,
+          "Q_bytes": 3320064,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.63,
+            "H20": 0.83
+          },
+          "prod_us": {
+            "XPU-A": 8.1
+          }
+        },
+        "7": {
+          "description": "(vLLM), RMSNorm, tokens=1200 hidden=1152",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 1200,
+            "hidden_size": 1152
+          },
+          "W_flops": 4148400,
+          "Q_bytes": 5531904,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 1.04,
+            "H20": 1.38
+          },
+          "prod_us": {
+            "XPU-A": 9.2
+          }
+        },
+        "8": {
+          "description": "(vLLM), RMSNorm, tokens=2116 hidden=1152",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 2116,
+            "hidden_size": 1152
+          },
+          "W_flops": 7315012,
+          "Q_bytes": 9752832,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.84,
+            "H20": 2.44
+          },
+          "prod_us": {
+            "XPU-A": 12.3
+          }
+        },
+        "9": {
+          "description": "(vLLM), RMSNorm, tokens=3844 hidden=1152",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 3844,
+            "hidden_size": 1152
+          },
+          "W_flops": 13288708,
+          "Q_bytes": 17715456,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 3.34,
+            "H20": 4.43
+          },
+          "prod_us": {
+            "XPU-A": 17.7
+          }
+        },
+        "10": {
+          "description": "(vLLM), RMSNorm, tokens=8136 hidden=1152",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 8136,
+            "hidden_size": 1152
+          },
+          "W_flops": 28126152,
+          "Q_bytes": 37492992,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 7.07,
+            "H20": 9.37
+          },
+          "prod_us": {
+            "XPU-A": 31.1
+          }
+        },
+        "11": {
+          "description": "(vLLM), RMSNorm, tokens=15000 hidden=1152",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 15000,
+            "hidden_size": 1152
+          },
+          "W_flops": 51855000,
+          "Q_bytes": 69122304,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 13.04,
+            "H20": 17.28
+          },
+          "prod_us": {
+            "XPU-A": 52.1
+          }
+        },
+        "12": {
+          "description": "(vLLM), RMSNorm, tokens=24368 hidden=1152",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 24368,
+            "hidden_size": 1152
+          },
+          "W_flops": 84240176,
+          "Q_bytes": 112290048,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 21.19,
+            "H20": 28.07
+          },
+          "prod_us": {
+            "XPU-A": 81.2
+          }
+        },
+        "13": {
+          "description": "(vLLM), RMSNorm, tokens=49152 hidden=1152",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 49152,
+            "hidden_size": 1152
+          },
+          "W_flops": 169918464,
+          "Q_bytes": 226494720,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 42.73,
+            "H20": 56.62
+          },
+          "prod_us": {
+            "XPU-A": 157.4
+          }
+        },
+        "14": {
+          "description": "(vLLM), RMSNorm, tokens=65556 hidden=1152",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 65556,
+            "hidden_size": 1152
+          },
+          "W_flops": 226627092,
+          "Q_bytes": 302084352,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 57.0,
+            "H20": 75.52
+          },
+          "prod_us": {
+            "XPU-A": 208.0
+          }
+        },
+        "15": {
+          "description": "(SGLang), RMSNorm, tokens=3 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 3,
+            "hidden_size": 128
+          },
+          "W_flops": 1155,
+          "Q_bytes": 1792,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 7.5
+          }
+        },
+        "16": {
+          "description": "(SGLang), RMSNorm, tokens=1504 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 1504,
+            "hidden_size": 128
+          },
+          "W_flops": 579040,
+          "Q_bytes": 770304,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.15,
+            "H20": 0.19
+          },
+          "prod_us": {
+            "XPU-A": 7.7
+          }
+        },
+        "17": {
+          "description": "(SGLang), RMSNorm, tokens=2048 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "hidden_size": 128
+          },
+          "W_flops": 788480,
+          "Q_bytes": 1048832,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.2,
+            "H20": 0.26
+          },
+          "prod_us": {
+            "XPU-A": 7.7
+          }
+        },
+        "18": {
+          "description": "(SGLang), RMSNorm, tokens=4096 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 4096,
+            "hidden_size": 128
+          },
+          "W_flops": 1576960,
+          "Q_bytes": 2097408,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.4,
+            "H20": 0.52
+          },
+          "prod_us": {
+            "XPU-A": 8.7
+          }
+        },
+        "19": {
+          "description": "(SGLang), RMSNorm, tokens=8192 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 8192,
+            "hidden_size": 128
+          },
+          "W_flops": 3153920,
+          "Q_bytes": 4194560,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.79,
+            "H20": 1.05
+          },
+          "prod_us": {
+            "XPU-A": 11.8
+          }
+        },
+        "20": {
+          "description": "(SGLang), RMSNorm, tokens=16384 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 16384,
+            "hidden_size": 128
+          },
+          "W_flops": 6307840,
+          "Q_bytes": 8388864,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.58,
+            "H20": 2.1
+          },
+          "prod_us": {
+            "XPU-A": 18.5
+          }
+        },
+        "21": {
+          "description": "(SGLang), RMSNorm, tokens=24544 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 24544,
+            "hidden_size": 128
+          },
+          "W_flops": 9449440,
+          "Q_bytes": 12566784,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 2.37,
+            "H20": 3.14
+          },
+          "prod_us": {
+            "XPU-A": 24.4
+          }
+        },
+        "22": {
+          "description": "(SGLang), RMSNorm, tokens=49024 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 49024,
+            "hidden_size": 128
+          },
+          "W_flops": 18874240,
+          "Q_bytes": 25100544,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 4.74,
+            "H20": 6.28
+          },
+          "prod_us": {
+            "XPU-A": 42.0
+          }
+        },
+        "23": {
+          "description": "(vLLM), RMSNorm, tokens=65488 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 65488,
+            "hidden_size": 128
+          },
+          "W_flops": 25212880,
+          "Q_bytes": 33530112,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 6.33,
+            "H20": 8.38
+          },
+          "prod_us": {
+            "XPU-A": 53.9
+          }
+        },
+        "24": {
+          "description": "(vLLM), RMSNorm, tokens=95952 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 95952,
+            "hidden_size": 128
+          },
+          "W_flops": 36941520,
+          "Q_bytes": 49127680,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 9.27,
+            "H20": 12.28
+          },
+          "prod_us": {
+            "XPU-A": 75.8
+          }
+        },
+        "25": {
+          "description": "(vLLM), RMSNorm, tokens=131072 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 131072,
+            "hidden_size": 128
+          },
+          "W_flops": 50462720,
+          "Q_bytes": 67109120,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 12.66,
+            "H20": 16.78
+          },
+          "prod_us": {
+            "XPU-A": 101.1
+          }
+        },
+        "26": {
+          "description": "(vLLM), RMSNorm, tokens=247680 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 247680,
+            "hidden_size": 128
+          },
+          "W_flops": 95356800,
+          "Q_bytes": 126812416,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 23.93,
+            "H20": 31.7
+          },
+          "prod_us": {
+            "XPU-A": 190.8
+          }
+        },
+        "27": {
+          "description": "(SGLang), RMSNorm, tokens=505888 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 505888,
+            "hidden_size": 128
+          },
+          "W_flops": 194766880,
+          "Q_bytes": 259014912,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 48.87,
+            "H20": 64.75
+          },
+          "prod_us": {
+            "XPU-A": 371.2
+          }
+        },
+        "28": {
+          "description": "(vLLM), RMSNorm, tokens=7 hidden=1280",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 7,
+            "hidden_size": 1280
+          },
+          "W_flops": 26887,
+          "Q_bytes": 38400,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 7.5
+          }
+        },
+        "29": {
+          "description": "(rtp-llm), RMSNorm, tokens=24752 hidden=1280",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 24752,
+            "hidden_size": 1280
+          },
+          "W_flops": 95072432,
+          "Q_bytes": 126732800,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 23.91,
+            "H20": 31.68
+          },
+          "prod_us": {
+            "XPU-A": 82.1
+          }
+        },
+        "30": {
+          "description": "(vLLM), RMSNorm, tokens=1736 hidden=1536",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 1736,
+            "hidden_size": 1536
+          },
+          "W_flops": 8001224,
+          "Q_bytes": 10669056,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 2.01,
+            "H20": 2.67
+          },
+          "prod_us": {
+            "XPU-A": 11.6
+          }
+        },
+        "31": {
+          "description": "(vLLM), RMSNorm, tokens=5000 hidden=1536",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 5000,
+            "hidden_size": 1536
+          },
+          "W_flops": 23045000,
+          "Q_bytes": 30723072,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 5.8,
+            "H20": 7.68
+          },
+          "prod_us": {
+            "XPU-A": 22.1
+          }
+        },
+        "32": {
+          "description": "(SGLang), RMSNorm, tokens=128 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 128,
+            "hidden_size": 2048
+          },
+          "W_flops": 786560,
+          "Q_bytes": 1052672,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.2,
+            "H20": 0.26
+          },
+          "prod_us": {
+            "XPU-A": 7.7
+          }
+        },
+        "33": {
+          "description": "(SGLang), RMSNorm, tokens=256 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 256,
+            "hidden_size": 2048
+          },
+          "W_flops": 1573120,
+          "Q_bytes": 2101248,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.4,
+            "H20": 0.53
+          },
+          "prod_us": {
+            "XPU-A": 7.8
+          }
+        },
+        "34": {
+          "description": "(SGLang), RMSNorm, tokens=512 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 512,
+            "hidden_size": 2048
+          },
+          "W_flops": 3146240,
+          "Q_bytes": 4198400,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.79,
+            "H20": 1.05
+          },
+          "prod_us": {
+            "XPU-A": 8.2
+          }
+        },
+        "35": {
+          "description": "(SGLang), RMSNorm, tokens=1029 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 1029,
+            "hidden_size": 2048
+          },
+          "W_flops": 6323205,
+          "Q_bytes": 8433664,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 1.59,
+            "H20": 2.11
+          },
+          "prod_us": {
+            "XPU-A": 9.1
+          }
+        },
+        "36": {
+          "description": "(vLLM TP1), RMSNorm, tokens=2010 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 2010,
+            "hidden_size": 2048
+          },
+          "W_flops": 12351450,
+          "Q_bytes": 16470016,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.11,
+            "H20": 4.12
+          },
+          "prod_us": {
+            "XPU-A": 12.6
+          }
+        },
+        "37": {
+          "description": "(SGLang), RMSNorm, tokens=4174 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 4174,
+            "hidden_size": 2048
+          },
+          "W_flops": 25649230,
+          "Q_bytes": 34197504,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 6.45,
+            "H20": 8.55
+          },
+          "prod_us": {
+            "XPU-A": 21.0
+          }
+        },
+        "38": {
+          "description": "(vLLM), RMSNorm, tokens=8290 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 8290,
+            "hidden_size": 2048
+          },
+          "W_flops": 50942050,
+          "Q_bytes": 67915776,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 12.81,
+            "H20": 16.98
+          },
+          "prod_us": {
+            "XPU-A": 34.9
+          }
+        },
+        "39": {
+          "description": "(vLLM), RMSNorm, tokens=16530 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 16530,
+            "hidden_size": 2048
+          },
+          "W_flops": 101576850,
+          "Q_bytes": 135417856,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 25.55,
+            "H20": 33.85
+          },
+          "prod_us": {
+            "XPU-A": 62.8
+          }
+        },
+        "40": {
+          "description": "(vLLM), RMSNorm, tokens=20538 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 20538,
+            "hidden_size": 2048
+          },
+          "W_flops": 126206010,
+          "Q_bytes": 168251392,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 31.75,
+            "H20": 42.06
+          },
+          "prod_us": {
+            "XPU-A": 80.5
+          }
+        },
+        "41": {
+          "description": "(SGLang), RMSNorm, tokens=3 hidden=256",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 3,
+            "hidden_size": 256
+          },
+          "W_flops": 2307,
+          "Q_bytes": 3584,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 7.5
+          }
+        },
+        "42": {
+          "description": "(SGLang), RMSNorm, tokens=1672 hidden=2560",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 1672,
+            "hidden_size": 2560
+          },
+          "W_flops": 12842632,
+          "Q_bytes": 17126400,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.23,
+            "H20": 4.28
+          },
+          "prod_us": {
+            "XPU-A": 14.2
+          }
+        },
+        "43": {
+          "description": "(vLLM TP1), RMSNorm, tokens=298 hidden=3584",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 298,
+            "hidden_size": 3584
+          },
+          "W_flops": 3204394,
+          "Q_bytes": 4279296,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.81,
+            "H20": 1.07
+          },
+          "prod_us": {
+            "XPU-A": 7.9
+          }
+        },
+        "44": {
+          "description": "(vLLM TP1), RMSNorm, tokens=514 hidden=3584",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 514,
+            "hidden_size": 3584
+          },
+          "W_flops": 5527042,
+          "Q_bytes": 7375872,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 1.39,
+            "H20": 1.84
+          },
+          "prod_us": {
+            "XPU-A": 8.7
+          }
+        },
+        "45": {
+          "description": "(vLLM TP1), RMSNorm, tokens=1024 hidden=3584",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 1024,
+            "hidden_size": 3584
+          },
+          "W_flops": 11011072,
+          "Q_bytes": 14687232,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 2.77,
+            "H20": 3.67
+          },
+          "prod_us": {
+            "XPU-A": 11.4
+          }
+        },
+        "46": {
+          "description": "(SGLang), RMSNorm, tokens=3 hidden=512",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 3,
+            "hidden_size": 512
+          },
+          "W_flops": 4611,
+          "Q_bytes": 7168,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 7.4
+          }
+        },
+        "47": {
+          "description": "(rtp-llm TP1), RMSNorm, tokens=1 hidden=5120",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "hidden_size": 5120
+          },
+          "W_flops": 15361,
+          "Q_bytes": 30720,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 7.5
+          }
+        },
+        "48": {
+          "description": "(SGLang TP8), RMSNorm, tokens=53 hidden=7168",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 53,
+            "hidden_size": 7168
+          },
+          "W_flops": 1139765,
+          "Q_bytes": 1533952,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.29,
+            "H20": 0.38
+          },
+          "prod_us": {
+            "XPU-A": 7.7
+          }
+        },
+        "49": {
+          "description": "(SGLang TP8), RMSNorm, tokens=141 hidden=7168",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 141,
+            "hidden_size": 7168
+          },
+          "W_flops": 3032205,
+          "Q_bytes": 4057088,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.77,
+            "H20": 1.01
+          },
+          "prod_us": {
+            "XPU-A": 7.9
+          }
+        },
+        "50": {
+          "description": "(SGLang TP8), RMSNorm, tokens=632 hidden=7168",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 632,
+            "hidden_size": 7168
+          },
+          "W_flops": 13591160,
+          "Q_bytes": 18135040,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.42,
+            "H20": 4.53
+          },
+          "prod_us": {
+            "XPU-A": 12.9
+          }
+        },
+        "51": {
+          "description": "(SGLang TP8), RMSNorm, tokens=917 hidden=7168",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 917,
+            "hidden_size": 7168
+          },
+          "W_flops": 19720085,
+          "Q_bytes": 26306560,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 4.96,
+            "H20": 6.58
+          },
+          "prod_us": {
+            "XPU-A": 16.4
+          }
+        },
+        "52": {
+          "description": "(SGLang/vLLM), RMSNorm, tokens=1688 hidden=7168",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 1688,
+            "hidden_size": 7168
+          },
+          "W_flops": 36300440,
+          "Q_bytes": 48412672,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 9.13,
+            "H20": 12.1
+          },
+          "prod_us": {
+            "XPU-A": 24.9
+          }
+        },
+        "53": {
+          "description": "(SGLang/vLLM), RMSNorm, tokens=3804 hidden=7168",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 3804,
+            "hidden_size": 7168
+          },
+          "W_flops": 81805020,
+          "Q_bytes": 109082624,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 20.58,
+            "H20": 27.27
+          },
+          "prod_us": {
+            "XPU-A": 46.5
+          }
+        },
+        "54": {
+          "description": "(SGLang), RMSNorm, tokens=154 hidden=8192",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 154,
+            "hidden_size": 8192
+          },
+          "W_flops": 3784858,
+          "Q_bytes": 5062656,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.96,
+            "H20": 1.27
+          },
+          "prod_us": {
+            "XPU-A": 8.0
+          }
+        },
+        "55": {
+          "description": "(SGLang), RMSNorm, tokens=510 hidden=8192",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 510,
+            "hidden_size": 8192
+          },
+          "W_flops": 12534270,
+          "Q_bytes": 16728064,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.16,
+            "H20": 4.18
+          },
+          "prod_us": {
+            "XPU-A": 12.4
+          }
+        }
+      }
+    },
+    {
+      "name": "mla_decode_attention",
+      "id": "atrex_018",
+      "dtype": "bf16",
+      "framework": "aiter",
+      "symbol": "mla_decode_stage1_asm_fwd",
+      "module": "aiter.mla",
+      "phase": "decode",
+      "shapes": 3,
+      "importance": 0.022828,
+      "roofline": {
+        "median_ai": 34.2,
+        "regime": "compute-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 180649984,
+          "Q_bytes": 1703952,
+          "ai": 106.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.78,
+            "H20": 1.22
+          },
+          "description": "(sglang TP2), MLA decode attention, nhead=128 kv_lora_rank=512 rope_dim=64"
+        },
+        "1": {
+          "W_flops": 11281408,
+          "Q_bytes": 329732,
+          "ai": 34.2,
+          "SOL_time_ms": {
+            "XPU-A": 0.06,
+            "H20": 0.08
+          },
+          "description": "(SGLang TP8), MLA decode attention, grid=(0,0,0)"
+        },
+        "2": {
+          "W_flops": 78969856,
+          "Q_bytes": 2308124,
+          "ai": 34.2,
+          "SOL_time_ms": {
+            "XPU-A": 0.44,
+            "H20": 0.58
+          },
+          "description": "(SGLang TP8), MLA decode attention, grid=(7,1,1)"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 3,
+          "median_us": 21.0,
+          "min_us": 19.0,
+          "max_us": 46.7,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 46.7,
+          "1": 19.0,
+          "2": 21.0
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self, nhead: int, kv_lora_rank: int, qk_rope_head_dim: int) -> None:\n        super().__init__()\n        self.nhead = nhead\n        self.kv_lora_rank = kv_lora_rank\n        self.qk_rope_head_dim = qk_rope_head_dim\n        self.qk_head_dim = kv_lora_rank + qk_rope_head_dim\n        self.v_head_dim = kv_lora_rank\n\n    def forward(self, q: torch.Tensor, kv_cache: torch.Tensor, seq_lens: torch.Tensor) -> torch.Tensor:\n        batch_size = seq_lens.shape[0]\n        out = torch.empty(batch_size, self.nhead, self.v_head_dim, dtype=torch.float32, device=q.device)\n        seq_lens_list = seq_lens.tolist()\n        kv_offset = 0\n        for i in range(batch_size):\n            seq_len = int(seq_lens_list[i])\n            kvc_i = kv_cache[kv_offset:kv_offset + seq_len].float()\n            q_i = q[i].float().unsqueeze(0).unsqueeze(2)\n            k_i = kvc_i.permute(1, 0, 2).expand(self.nhead, seq_len, self.qk_head_dim).unsqueeze(0)\n            v_i = kvc_i[..., :self.kv_lora_rank].permute(1, 0, 2).expand(self.nhead, seq_len, self.v_head_dim).unsqueeze(0)\n            o_i = F.scaled_dot_product_attention(q_i, k_i, v_i, is_causal=False)\n            out[i] = o_i.squeeze(0).squeeze(1)\n            kv_offset += seq_len\n        return out.to(q.dtype)\n",
+      "input_code": "import torch\n\n\ndef _make_inputs(batch_size: int, ctx_len: int, nhead: int, kv_lora_rank: int, qk_rope_head_dim: int) -> dict[str, torch.Tensor]:\n    qk_head_dim = kv_lora_rank + qk_rope_head_dim\n    q = torch.randn(batch_size, nhead, qk_head_dim, dtype=torch.bfloat16, device='cuda')\n    total_kv = batch_size * ctx_len\n    kv_cache = torch.randn(total_kv, 1, kv_lora_rank + qk_rope_head_dim, dtype=torch.bfloat16, device='cuda')\n    seq_lens = torch.full((batch_size,), ctx_len, dtype=torch.int32, device='cuda')\n    return {'q': q, 'kv_cache': kv_cache, 'seq_lens': seq_lens}\n",
+      "shape_details": {
+        "0": {
+          "description": "(sglang TP2), MLA decode attention, nhead=128 kv_lora_rank=512 rope_dim=64",
+          "init_kwargs": {
+            "nhead": 128,
+            "kv_lora_rank": 512,
+            "qk_rope_head_dim": 64
+          },
+          "input_kwargs": {
+            "batch_size": 4,
+            "ctx_len": 128,
+            "nhead": 128,
+            "kv_lora_rank": 512,
+            "qk_rope_head_dim": 64
+          },
+          "W_flops": 180649984,
+          "Q_bytes": 1703952,
+          "ai": 106.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.78,
+            "H20": 1.22
+          },
+          "prod_us": {
+            "XPU-A": 46.7
+          }
+        },
+        "1": {
+          "description": "(SGLang TP8), MLA decode attention, grid=(0,0,0)",
+          "init_kwargs": {
+            "nhead": 16,
+            "kv_lora_rank": 512,
+            "qk_rope_head_dim": 64
+          },
+          "input_kwargs": {
+            "batch_size": 1,
+            "ctx_len": 256,
+            "nhead": 16,
+            "kv_lora_rank": 512,
+            "qk_rope_head_dim": 64
+          },
+          "W_flops": 11281408,
+          "Q_bytes": 329732,
+          "ai": 34.2,
+          "SOL_time_ms": {
+            "XPU-A": 0.06,
+            "H20": 0.08
+          },
+          "prod_us": {
+            "XPU-A": 19.0
+          }
+        },
+        "2": {
+          "description": "(SGLang TP8), MLA decode attention, grid=(7,1,1)",
+          "init_kwargs": {
+            "nhead": 16,
+            "kv_lora_rank": 512,
+            "qk_rope_head_dim": 64
+          },
+          "input_kwargs": {
+            "batch_size": 7,
+            "ctx_len": 256,
+            "nhead": 16,
+            "kv_lora_rank": 512,
+            "qk_rope_head_dim": 64
+          },
+          "W_flops": 78969856,
+          "Q_bytes": 2308124,
+          "ai": 34.2,
+          "SOL_time_ms": {
+            "XPU-A": 0.44,
+            "H20": 0.58
+          },
+          "prod_us": {
+            "XPU-A": 21.0
+          }
+        }
+      }
+    },
+    {
+      "name": "attention_forward",
+      "id": "atrex_001",
+      "dtype": "bf16",
+      "framework": "vllm",
+      "symbol": "attention_forward_varlen",
+      "module": "ck_tile FmhaFwdKernel / attn_fwd raw trace",
+      "phase": "prefill",
+      "shapes": 21,
+      "importance": 0.022438,
+      "roofline": {
+        "median_ai": 4068.0,
+        "regime": "compute-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 2388787200,
+          "Q_bytes": 6635536,
+          "ai": 360.0,
+          "SOL_time_ms": {
+            "XPU-A": 10.27,
+            "H20": 16.14
+          },
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(720,16,72)"
+        },
+        "1": {
+          "W_flops": 6635520000,
+          "Q_bytes": 11059216,
+          "ai": 600.0,
+          "SOL_time_ms": {
+            "XPU-A": 28.52,
+            "H20": 44.83
+          },
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(1200,16,72)"
+        },
+        "2": {
+          "W_flops": 20632117248,
+          "Q_bytes": 19501072,
+          "ai": 1058.0,
+          "SOL_time_ms": {
+            "XPU-A": 88.68,
+            "H20": 139.41
+          },
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(2116,16,72)"
+        },
+        "3": {
+          "W_flops": 68089356288,
+          "Q_bytes": 35426320,
+          "ai": 1922.0,
+          "SOL_time_ms": {
+            "XPU-A": 292.67,
+            "H20": 460.06
+          },
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(3844,16,72)"
+        },
+        "4": {
+          "W_flops": 305024237568,
+          "Q_bytes": 74981392,
+          "ai": 4068.0,
+          "SOL_time_ms": {
+            "XPU-A": 1311.09,
+            "H20": 2060.97
+          },
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(8136,16,72)"
+        },
+        "5": {
+          "W_flops": 1378490646528,
+          "Q_bytes": 159399952,
+          "ai": 8648.0,
+          "SOL_time_ms": {
+            "XPU-A": 5925.17,
+            "H20": 9314.13
+          },
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(17296,16,72)"
+        },
+        "6": {
+          "W_flops": 2736227745792,
+          "Q_bytes": 224575504,
+          "ai": 12184.0,
+          "SOL_time_ms": {
+            "XPU-A": 11761.13,
+            "H20": 18488.03
+          },
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(24368,16,72)"
+        },
+        "7": {
+          "W_flops": 11334588899328,
+          "Q_bytes": 457076752,
+          "ai": 24798.0,
+          "SOL_time_ms": {
+            "XPU-A": 48719.49,
+            "H20": 76585.06
+          },
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(49596,16,72)"
+        },
+        "8": {
+          "W_flops": 19803290738688,
+          "Q_bytes": 604164112,
+          "ai": 32778.0,
+          "SOL_time_ms": {
+            "XPU-A": 85120.53,
+            "H20": 133806.02
+          },
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(65556,16,72)"
+        },
+        "9": {
+          "W_flops": 4592346136576,
+          "Q_bytes": 548601872,
+          "ai": 8371.0,
+          "SOL_time_ms": {
+            "XPU-A": 19739.29,
+            "H20": 31029.37
+          },
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(16742,32,128)"
+        },
+        "10": {
+          "W_flops": 15535453782016,
+          "Q_bytes": 1009025040,
+          "ai": 15396.5,
+          "SOL_time_ms": {
+            "XPU-A": 66776.07,
+            "H20": 104969.28
+          },
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(30793,32,128)"
+        },
+        "11": {
+          "W_flops": 87754752,
+          "Q_bytes": 635920,
+          "ai": 138.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.38,
+            "H20": 0.59
+          },
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(276,4,72)"
+        },
+        "12": {
+          "W_flops": 414720000,
+          "Q_bytes": 1382416,
+          "ai": 300.0,
+          "SOL_time_ms": {
+            "XPU-A": 1.78,
+            "H20": 2.8
+          },
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(600,4,72)"
+        },
+        "13": {
+          "W_flops": 1179813888,
+          "Q_bytes": 2331664,
+          "ai": 506.0,
+          "SOL_time_ms": {
+            "XPU-A": 5.07,
+            "H20": 7.97
+          },
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(1012,4,72)"
+        },
+        "14": {
+          "W_flops": 4719255552,
+          "Q_bytes": 4663312,
+          "ai": 1012.0,
+          "SOL_time_ms": {
+            "XPU-A": 20.28,
+            "H20": 31.89
+          },
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(2024,4,72)"
+        },
+        "15": {
+          "W_flops": 19365120000,
+          "Q_bytes": 9446416,
+          "ai": 2050.0,
+          "SOL_time_ms": {
+            "XPU-A": 83.24,
+            "H20": 130.85
+          },
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(4100,4,72)"
+        },
+        "16": {
+          "W_flops": 77158490112,
+          "Q_bytes": 18855952,
+          "ai": 4092.0,
+          "SOL_time_ms": {
+            "XPU-A": 331.65,
+            "H20": 521.34
+          },
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(8184,4,72)"
+        },
+        "17": {
+          "W_flops": 275911575552,
+          "Q_bytes": 35656720,
+          "ai": 7738.0,
+          "SOL_time_ms": {
+            "XPU-A": 1185.95,
+            "H20": 1864.27
+          },
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(15476,4,72)"
+        },
+        "18": {
+          "W_flops": 717237854208,
+          "Q_bytes": 57489424,
+          "ai": 12476.0,
+          "SOL_time_ms": {
+            "XPU-A": 3082.91,
+            "H20": 4846.2
+          },
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(24952,4,72)"
+        },
+        "19": {
+          "W_flops": 1895170867200,
+          "Q_bytes": 93450256,
+          "ai": 20280.0,
+          "SOL_time_ms": {
+            "XPU-A": 8146.02,
+            "H20": 12805.21
+          },
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(40560,4,72)"
+        },
+        "20": {
+          "W_flops": 4096,
+          "Q_bytes": 8208,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(rtp-llm TP1), prefill attention forward, q/k/v=(1,8,128)"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 21,
+          "median_us": 1173.6,
+          "min_us": 14.4,
+          "max_us": 237709.9,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 68.4,
+          "1": 108.1,
+          "2": 332.7,
+          "3": 1018.0,
+          "4": 3791.1,
+          "5": 17072.6,
+          "6": 33271.9,
+          "7": 134507.1,
+          "8": 237709.9,
+          "9": 37320.4,
+          "10": 124192.8,
+          "11": 43.2,
+          "12": 47.4,
+          "13": 57.0,
+          "14": 105.5,
+          "15": 308.7,
+          "16": 1173.6,
+          "17": 3746.7,
+          "18": 8546.0,
+          "19": 21902.8,
+          "20": 14.4
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self) -> None:\n        super().__init__()\n\n    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, cu_seqlens_q: torch.Tensor, cu_seqlens_k: torch.Tensor) -> torch.Tensor:\n        out = torch.empty_like(q)\n        q_bounds = cu_seqlens_q.tolist()\n        k_bounds = cu_seqlens_k.tolist()\n        for seq_idx in range(len(q_bounds) - 1):\n            qs_start, qs_end = q_bounds[seq_idx], q_bounds[seq_idx + 1]\n            ks_start, ks_end = k_bounds[seq_idx], k_bounds[seq_idx + 1]\n            if qs_end <= qs_start:\n                continue\n            qs = q[qs_start:qs_end].transpose(0, 1).unsqueeze(0).float()\n            ks = k[ks_start:ks_end].transpose(0, 1).unsqueeze(0).float()\n            vs = v[ks_start:ks_end].transpose(0, 1).unsqueeze(0).float()\n            os = F.scaled_dot_product_attention(qs, ks, vs, is_causal=False)\n            out[qs_start:qs_end] = os.squeeze(0).transpose(0, 1).to(q.dtype)\n        return out\n",
+      "input_code": "import torch\n\ndef _make_inputs(seq_lens: list[int], num_heads: int, head_dim: int) -> dict[str, torch.Tensor]:\n    total_tokens = sum(seq_lens)\n    q = torch.randn(total_tokens, num_heads, head_dim, dtype=torch.bfloat16, device='cuda')\n    k = torch.randn(total_tokens, num_heads, head_dim, dtype=torch.bfloat16, device='cuda')\n    v = torch.randn(total_tokens, num_heads, head_dim, dtype=torch.bfloat16, device='cuda')\n    cu_seqlens_q = torch.zeros(len(seq_lens) + 1, dtype=torch.int32, device='cuda')\n    cu_seqlens_k = torch.zeros(len(seq_lens) + 1, dtype=torch.int32, device='cuda')\n    for i, sl in enumerate(seq_lens):\n        cu_seqlens_q[i + 1] = cu_seqlens_q[i] + sl\n        cu_seqlens_k[i + 1] = cu_seqlens_k[i] + sl\n    return {'q': q, 'k': k, 'v': v, 'cu_seqlens_q': cu_seqlens_q, 'cu_seqlens_k': cu_seqlens_k}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(720,16,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 16,
+            "head_dim": 72,
+            "seq_lens": [
+              720
+            ]
+          },
+          "W_flops": 2388787200,
+          "Q_bytes": 6635536,
+          "ai": 360.0,
+          "SOL_time_ms": {
+            "XPU-A": 10.27,
+            "H20": 16.14
+          },
+          "prod_us": {
+            "XPU-A": 68.4
+          }
+        },
+        "1": {
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(1200,16,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 16,
+            "head_dim": 72,
+            "seq_lens": [
+              1200
+            ]
+          },
+          "W_flops": 6635520000,
+          "Q_bytes": 11059216,
+          "ai": 600.0,
+          "SOL_time_ms": {
+            "XPU-A": 28.52,
+            "H20": 44.83
+          },
+          "prod_us": {
+            "XPU-A": 108.1
+          }
+        },
+        "2": {
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(2116,16,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 16,
+            "head_dim": 72,
+            "seq_lens": [
+              2116
+            ]
+          },
+          "W_flops": 20632117248,
+          "Q_bytes": 19501072,
+          "ai": 1058.0,
+          "SOL_time_ms": {
+            "XPU-A": 88.68,
+            "H20": 139.41
+          },
+          "prod_us": {
+            "XPU-A": 332.7
+          }
+        },
+        "3": {
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(3844,16,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 16,
+            "head_dim": 72,
+            "seq_lens": [
+              3844
+            ]
+          },
+          "W_flops": 68089356288,
+          "Q_bytes": 35426320,
+          "ai": 1922.0,
+          "SOL_time_ms": {
+            "XPU-A": 292.67,
+            "H20": 460.06
+          },
+          "prod_us": {
+            "XPU-A": 1018.0
+          }
+        },
+        "4": {
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(8136,16,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 16,
+            "head_dim": 72,
+            "seq_lens": [
+              8136
+            ]
+          },
+          "W_flops": 305024237568,
+          "Q_bytes": 74981392,
+          "ai": 4068.0,
+          "SOL_time_ms": {
+            "XPU-A": 1311.09,
+            "H20": 2060.97
+          },
+          "prod_us": {
+            "XPU-A": 3791.1
+          }
+        },
+        "5": {
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(17296,16,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 16,
+            "head_dim": 72,
+            "seq_lens": [
+              17296
+            ]
+          },
+          "W_flops": 1378490646528,
+          "Q_bytes": 159399952,
+          "ai": 8648.0,
+          "SOL_time_ms": {
+            "XPU-A": 5925.17,
+            "H20": 9314.13
+          },
+          "prod_us": {
+            "XPU-A": 17072.6
+          }
+        },
+        "6": {
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(24368,16,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 16,
+            "head_dim": 72,
+            "seq_lens": [
+              24368
+            ]
+          },
+          "W_flops": 2736227745792,
+          "Q_bytes": 224575504,
+          "ai": 12184.0,
+          "SOL_time_ms": {
+            "XPU-A": 11761.13,
+            "H20": 18488.03
+          },
+          "prod_us": {
+            "XPU-A": 33271.9
+          }
+        },
+        "7": {
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(49596,16,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 16,
+            "head_dim": 72,
+            "seq_lens": [
+              49596
+            ]
+          },
+          "W_flops": 11334588899328,
+          "Q_bytes": 457076752,
+          "ai": 24798.0,
+          "SOL_time_ms": {
+            "XPU-A": 48719.49,
+            "H20": 76585.06
+          },
+          "prod_us": {
+            "XPU-A": 134507.1
+          }
+        },
+        "8": {
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(65556,16,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 16,
+            "head_dim": 72,
+            "seq_lens": [
+              65556
+            ]
+          },
+          "W_flops": 19803290738688,
+          "Q_bytes": 604164112,
+          "ai": 32778.0,
+          "SOL_time_ms": {
+            "XPU-A": 85120.53,
+            "H20": 133806.02
+          },
+          "prod_us": {
+            "XPU-A": 237709.9
+          }
+        },
+        "9": {
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(16742,32,128)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 32,
+            "head_dim": 128,
+            "seq_lens": [
+              16742
+            ]
+          },
+          "W_flops": 4592346136576,
+          "Q_bytes": 548601872,
+          "ai": 8371.0,
+          "SOL_time_ms": {
+            "XPU-A": 19739.29,
+            "H20": 31029.37
+          },
+          "prod_us": {
+            "XPU-A": 37320.4
+          }
+        },
+        "10": {
+          "description": "(vLLM TP1), prefill attention forward, q/k/v=(30793,32,128)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 32,
+            "head_dim": 128,
+            "seq_lens": [
+              30793
+            ]
+          },
+          "W_flops": 15535453782016,
+          "Q_bytes": 1009025040,
+          "ai": 15396.5,
+          "SOL_time_ms": {
+            "XPU-A": 66776.07,
+            "H20": 104969.28
+          },
+          "prod_us": {
+            "XPU-A": 124192.8
+          }
+        },
+        "11": {
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(276,4,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 4,
+            "head_dim": 72,
+            "seq_lens": [
+              276
+            ]
+          },
+          "W_flops": 87754752,
+          "Q_bytes": 635920,
+          "ai": 138.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.38,
+            "H20": 0.59
+          },
+          "prod_us": {
+            "XPU-A": 43.2
+          }
+        },
+        "12": {
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(600,4,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 4,
+            "head_dim": 72,
+            "seq_lens": [
+              600
+            ]
+          },
+          "W_flops": 414720000,
+          "Q_bytes": 1382416,
+          "ai": 300.0,
+          "SOL_time_ms": {
+            "XPU-A": 1.78,
+            "H20": 2.8
+          },
+          "prod_us": {
+            "XPU-A": 47.4
+          }
+        },
+        "13": {
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(1012,4,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 4,
+            "head_dim": 72,
+            "seq_lens": [
+              1012
+            ]
+          },
+          "W_flops": 1179813888,
+          "Q_bytes": 2331664,
+          "ai": 506.0,
+          "SOL_time_ms": {
+            "XPU-A": 5.07,
+            "H20": 7.97
+          },
+          "prod_us": {
+            "XPU-A": 57.0
+          }
+        },
+        "14": {
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(2024,4,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 4,
+            "head_dim": 72,
+            "seq_lens": [
+              2024
+            ]
+          },
+          "W_flops": 4719255552,
+          "Q_bytes": 4663312,
+          "ai": 1012.0,
+          "SOL_time_ms": {
+            "XPU-A": 20.28,
+            "H20": 31.89
+          },
+          "prod_us": {
+            "XPU-A": 105.5
+          }
+        },
+        "15": {
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(4100,4,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 4,
+            "head_dim": 72,
+            "seq_lens": [
+              4100
+            ]
+          },
+          "W_flops": 19365120000,
+          "Q_bytes": 9446416,
+          "ai": 2050.0,
+          "SOL_time_ms": {
+            "XPU-A": 83.24,
+            "H20": 130.85
+          },
+          "prod_us": {
+            "XPU-A": 308.7
+          }
+        },
+        "16": {
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(8184,4,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 4,
+            "head_dim": 72,
+            "seq_lens": [
+              8184
+            ]
+          },
+          "W_flops": 77158490112,
+          "Q_bytes": 18855952,
+          "ai": 4092.0,
+          "SOL_time_ms": {
+            "XPU-A": 331.65,
+            "H20": 521.34
+          },
+          "prod_us": {
+            "XPU-A": 1173.6
+          }
+        },
+        "17": {
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(15476,4,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 4,
+            "head_dim": 72,
+            "seq_lens": [
+              15476
+            ]
+          },
+          "W_flops": 275911575552,
+          "Q_bytes": 35656720,
+          "ai": 7738.0,
+          "SOL_time_ms": {
+            "XPU-A": 1185.95,
+            "H20": 1864.27
+          },
+          "prod_us": {
+            "XPU-A": 3746.7
+          }
+        },
+        "18": {
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(24952,4,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 4,
+            "head_dim": 72,
+            "seq_lens": [
+              24952
+            ]
+          },
+          "W_flops": 717237854208,
+          "Q_bytes": 57489424,
+          "ai": 12476.0,
+          "SOL_time_ms": {
+            "XPU-A": 3082.91,
+            "H20": 4846.2
+          },
+          "prod_us": {
+            "XPU-A": 8546.0
+          }
+        },
+        "19": {
+          "description": "(vLLM TP4), prefill attention forward, q/k/v=(40560,4,72)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 4,
+            "head_dim": 72,
+            "seq_lens": [
+              40560
+            ]
+          },
+          "W_flops": 1895170867200,
+          "Q_bytes": 93450256,
+          "ai": 20280.0,
+          "SOL_time_ms": {
+            "XPU-A": 8146.02,
+            "H20": 12805.21
+          },
+          "prod_us": {
+            "XPU-A": 21902.8
+          }
+        },
+        "20": {
+          "description": "(rtp-llm TP1), prefill attention forward, q/k/v=(1,8,128)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "num_heads": 8,
+            "head_dim": 128,
+            "seq_lens": [
+              1
+            ]
+          },
+          "W_flops": 4096,
+          "Q_bytes": 8208,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 14.4
+          }
+        }
+      }
+    },
+    {
+      "name": "causal_conv1d",
+      "id": "atrex_003",
+      "dtype": "bf16",
+      "framework": "sglang",
+      "symbol": "causal_conv1d_fn",
+      "module": "sglang.srt.layers.attention.mamba.causal_conv1d_triton",
+      "phase": "prefill",
+      "shapes": 9,
+      "importance": 0.021834,
+      "roofline": {
+        "median_ai": 3.0,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 49152,
+          "Q_bytes": 81920,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.02,
+            "H20": 0.02
+          },
+          "description": "(SGLang TP1), causal depthwise conv1d, tokens=1 dim=4096 width=4"
+        },
+        "1": {
+          "W_flops": 6291456,
+          "Q_bytes": 2162688,
+          "ai": 2.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.41,
+            "H20": 0.54
+          },
+          "description": "(vLLM TP1), causal depthwise conv1d, tokens=128 dim=4096 width=4"
+        },
+        "2": {
+          "W_flops": 12582912,
+          "Q_bytes": 4259840,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.8,
+            "H20": 1.06
+          },
+          "description": "(vLLM TP1), causal depthwise conv1d, tokens=256 dim=4096 width=4"
+        },
+        "3": {
+          "W_flops": 25264128,
+          "Q_bytes": 8486912,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 1.6,
+            "H20": 2.12
+          },
+          "description": "(vLLM TP1), causal depthwise conv1d, tokens=514 dim=4096 width=4"
+        },
+        "4": {
+          "W_flops": 50331648,
+          "Q_bytes": 16842752,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 3.18,
+            "H20": 4.21
+          },
+          "description": "(vLLM TP1), causal depthwise conv1d, tokens=1024 dim=4096 width=4"
+        },
+        "5": {
+          "W_flops": 98304,
+          "Q_bytes": 163840,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.03,
+            "H20": 0.04
+          },
+          "description": "(SGLang TP8), causal depthwise conv1d, tokens=1 dim=8192 width=4"
+        },
+        "6": {
+          "W_flops": 412385280,
+          "Q_bytes": 137592832,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 25.96,
+            "H20": 34.4
+          },
+          "description": "(SGLang), causal depthwise conv1d, tokens=4195 dim=8192 width=4"
+        },
+        "7": {
+          "W_flops": 1083998208,
+          "Q_bytes": 361463808,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 68.2,
+            "H20": 90.37
+          },
+          "description": "(SGLang), causal depthwise conv1d, tokens=11027 dim=8192 width=4"
+        },
+        "8": {
+          "W_flops": 1455587328,
+          "Q_bytes": 485326848,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 91.57,
+            "H20": 121.33
+          },
+          "description": "(SGLang), causal depthwise conv1d, tokens=14807 dim=8192 width=4"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 9,
+          "median_us": 100.6,
+          "min_us": 7.6,
+          "max_us": 4659.6,
+          "framework": "sglang"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 7.6,
+          "1": 35.7,
+          "2": 77.1,
+          "3": 100.6,
+          "4": 272.4,
+          "5": 7.7,
+          "6": 1334.9,
+          "7": 3496.7,
+          "8": 4659.6
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self, activation: str | None='silu') -> None:\n        super().__init__()\n        self.activation = activation\n\n    def forward(self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor, initial_state: torch.Tensor) -> torch.Tensor:\n        dtype = x.dtype\n        seq = x.unsqueeze(0).to(weight.dtype)\n        state = initial_state.to(weight.dtype)\n        width = weight.shape[1]\n        seq_with_state = torch.cat([state[:, :, -(width - 1):], seq], dim=-1)\n        out = F.conv1d(seq_with_state, weight.unsqueeze(1), bias, groups=weight.shape[0])\n        out = out[:, :, -x.shape[-1]:]\n        if self.activation in ('silu', 'swish'):\n            out = F.silu(out)\n        elif self.activation is not None:\n            raise ValueError(f'unsupported activation: {self.activation}')\n        return out.squeeze(0).to(dtype)\n",
+      "input_code": "import torch\n\ndef _make_inputs(token_count: int, dim: int, width: int=4) -> dict[str, torch.Tensor]:\n    x = torch.randn(dim, token_count, dtype=torch.bfloat16, device='cuda') * 0.02\n    weight = torch.randn(dim, width, dtype=torch.bfloat16, device='cuda') * 0.02\n    bias = torch.randn(dim, dtype=torch.bfloat16, device='cuda') * 0.02\n    initial_state = torch.randn(1, dim, width - 1, dtype=torch.bfloat16, device='cuda') * 0.02\n    return {'x': x, 'weight': weight, 'bias': bias, 'initial_state': initial_state}\n",
+      "shape_details": {
+        "0": {
+          "description": "(SGLang TP1), causal depthwise conv1d, tokens=1 dim=4096 width=4",
+          "init_kwargs": {
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "dim": 4096,
+            "width": 4
+          },
+          "W_flops": 49152,
+          "Q_bytes": 81920,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.02,
+            "H20": 0.02
+          },
+          "prod_us": {
+            "XPU-A": 7.6
+          }
+        },
+        "1": {
+          "description": "(vLLM TP1), causal depthwise conv1d, tokens=128 dim=4096 width=4",
+          "init_kwargs": {
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "token_count": 128,
+            "dim": 4096,
+            "width": 4
+          },
+          "W_flops": 6291456,
+          "Q_bytes": 2162688,
+          "ai": 2.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.41,
+            "H20": 0.54
+          },
+          "prod_us": {
+            "XPU-A": 35.7
+          }
+        },
+        "2": {
+          "description": "(vLLM TP1), causal depthwise conv1d, tokens=256 dim=4096 width=4",
+          "init_kwargs": {
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "token_count": 256,
+            "dim": 4096,
+            "width": 4
+          },
+          "W_flops": 12582912,
+          "Q_bytes": 4259840,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.8,
+            "H20": 1.06
+          },
+          "prod_us": {
+            "XPU-A": 77.1
+          }
+        },
+        "3": {
+          "description": "(vLLM TP1), causal depthwise conv1d, tokens=514 dim=4096 width=4",
+          "init_kwargs": {
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "token_count": 514,
+            "dim": 4096,
+            "width": 4
+          },
+          "W_flops": 25264128,
+          "Q_bytes": 8486912,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 1.6,
+            "H20": 2.12
+          },
+          "prod_us": {
+            "XPU-A": 100.6
+          }
+        },
+        "4": {
+          "description": "(vLLM TP1), causal depthwise conv1d, tokens=1024 dim=4096 width=4",
+          "init_kwargs": {
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "token_count": 1024,
+            "dim": 4096,
+            "width": 4
+          },
+          "W_flops": 50331648,
+          "Q_bytes": 16842752,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 3.18,
+            "H20": 4.21
+          },
+          "prod_us": {
+            "XPU-A": 272.4
+          }
+        },
+        "5": {
+          "description": "(SGLang TP8), causal depthwise conv1d, tokens=1 dim=8192 width=4",
+          "init_kwargs": {
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "dim": 8192,
+            "width": 4
+          },
+          "W_flops": 98304,
+          "Q_bytes": 163840,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.03,
+            "H20": 0.04
+          },
+          "prod_us": {
+            "XPU-A": 7.7
+          }
+        },
+        "6": {
+          "description": "(SGLang), causal depthwise conv1d, tokens=4195 dim=8192 width=4",
+          "init_kwargs": {
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "token_count": 4195,
+            "dim": 8192,
+            "width": 4
+          },
+          "W_flops": 412385280,
+          "Q_bytes": 137592832,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 25.96,
+            "H20": 34.4
+          },
+          "prod_us": {
+            "XPU-A": 1334.9
+          }
+        },
+        "7": {
+          "description": "(SGLang), causal depthwise conv1d, tokens=11027 dim=8192 width=4",
+          "init_kwargs": {
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "token_count": 11027,
+            "dim": 8192,
+            "width": 4
+          },
+          "W_flops": 1083998208,
+          "Q_bytes": 361463808,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 68.2,
+            "H20": 90.37
+          },
+          "prod_us": {
+            "XPU-A": 3496.7
+          }
+        },
+        "8": {
+          "description": "(SGLang), causal depthwise conv1d, tokens=14807 dim=8192 width=4",
+          "init_kwargs": {
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "token_count": 14807,
+            "dim": 8192,
+            "width": 4
+          },
+          "W_flops": 1455587328,
+          "Q_bytes": 485326848,
+          "ai": 3.0,
+          "SOL_time_ms": {
+            "XPU-A": 91.57,
+            "H20": 121.33
+          },
+          "prod_us": {
+            "XPU-A": 4659.6
+          }
+        }
+      }
+    },
+    {
+      "name": "moe_topk_gating_softmax",
+      "id": "atrex_022",
+      "dtype": "fp32",
+      "framework": "vllm",
+      "symbol": "moe_topk_gating_softmax",
+      "module": "vllm._custom_ops",
+      "phase": "prefill/decode",
+      "shapes": 10,
+      "importance": 0.020529,
+      "roofline": {
+        "median_ai": 0.9,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 511,
+          "Q_bytes": 576,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(rtp-llm TP1), MoE routing topk_gating_softmax, tokens=1 experts=128"
+        },
+        "1": {
+          "W_flops": 65919,
+          "Q_bytes": 74304,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.02
+          },
+          "description": "(vLLM TP1), MoE routing topk_gating_softmax, tokens=129 experts=128"
+        },
+        "2": {
+          "W_flops": 130816,
+          "Q_bytes": 147456,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.03,
+            "H20": 0.04
+          },
+          "description": "(vLLM TP1), MoE routing topk_gating_softmax, tokens=256 experts=128"
+        },
+        "3": {
+          "W_flops": 265720,
+          "Q_bytes": 299520,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.06,
+            "H20": 0.07
+          },
+          "description": "(vLLM TP4), MoE routing topk_gating_softmax, tokens=520 experts=128"
+        },
+        "4": {
+          "W_flops": 520709,
+          "Q_bytes": 586944,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.11,
+            "H20": 0.15
+          },
+          "description": "(vLLM TP4), MoE routing topk_gating_softmax, tokens=1019 experts=128"
+        },
+        "5": {
+          "W_flops": 1044484,
+          "Q_bytes": 1177344,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.22,
+            "H20": 0.29
+          },
+          "description": "(vLLM TP4), MoE routing topk_gating_softmax, tokens=2044 experts=128"
+        },
+        "6": {
+          "W_flops": 2086413,
+          "Q_bytes": 2351808,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.44,
+            "H20": 0.59
+          },
+          "description": "(SGLang TP8), MoE routing topk_gating_softmax, tokens=4083 experts=128"
+        },
+        "7": {
+          "W_flops": 4186112,
+          "Q_bytes": 4718592,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.89,
+            "H20": 1.18
+          },
+          "description": "(vLLM TP4), MoE routing topk_gating_softmax, tokens=8192 experts=128"
+        },
+        "8": {
+          "W_flops": 8221851,
+          "Q_bytes": 8744256,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 1.65,
+            "H20": 2.19
+          },
+          "description": "(vLLM TP inferred), MoE routing topk_softmax, tokens=8037 experts=256"
+        },
+        "9": {
+          "W_flops": 13837098,
+          "Q_bytes": 14716288,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 2.78,
+            "H20": 3.68
+          },
+          "description": "(vLLM TP inferred), MoE routing topk_softmax, tokens=13526 experts=256"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 10,
+          "median_us": 13.3,
+          "min_us": 11.4,
+          "max_us": 56.2,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 11.4,
+          "1": 12.8,
+          "2": 13.0,
+          "3": 13.0,
+          "4": 13.1,
+          "5": 13.3,
+          "6": 17.1,
+          "7": 25.6,
+          "8": 39.4,
+          "9": 56.2
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self, top_k: int, num_expert_groups: int = 0, topk_group: int = 0) -> None:\n        super().__init__()\n        self.top_k = top_k\n        self.num_expert_groups = num_expert_groups\n        self.topk_group = topk_group\n\n    def forward(self, gating_output: torch.Tensor) -> dict[str, torch.Tensor]:\n        scores = torch.softmax(gating_output.float(), dim=-1)\n        if self.num_expert_groups > 0 and self.topk_group > 0:\n            n, ne = scores.shape\n            group_size = ne // self.num_expert_groups\n            grouped = scores.view(n, self.num_expert_groups, group_size)\n            group_scores = grouped.amax(dim=-1)\n            _, top_groups = torch.topk(group_scores, k=self.topk_group, dim=-1)\n            mask = torch.zeros(n, self.num_expert_groups, dtype=torch.bool, device=scores.device)\n            mask.scatter_(1, top_groups, True)\n            mask = mask.unsqueeze(-1).expand(-1, -1, group_size).reshape(n, ne)\n            scores = scores.masked_fill(~mask, 0.0)\n        (topk_weights, topk_ids) = torch.topk(scores, k=self.top_k, dim=-1)\n        return {'topk_weights': topk_weights, 'topk_ids': topk_ids.to(torch.int32)}\n",
+      "input_code": "import torch\n\ndef _make_inputs(token_count: int, num_experts: int) -> dict[str, torch.Tensor]:\n    gating_output = torch.randn(token_count, num_experts, dtype=torch.float32, device='cuda')\n    return {'gating_output': gating_output}\n",
+      "shape_details": {
+        "0": {
+          "description": "(rtp-llm TP1), MoE routing topk_gating_softmax, tokens=1 experts=128",
+          "init_kwargs": {
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "num_experts": 128
+          },
+          "W_flops": 511,
+          "Q_bytes": 576,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 11.4
+          }
+        },
+        "1": {
+          "description": "(vLLM TP1), MoE routing topk_gating_softmax, tokens=129 experts=128",
+          "init_kwargs": {
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 129,
+            "num_experts": 128
+          },
+          "W_flops": 65919,
+          "Q_bytes": 74304,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.02
+          },
+          "prod_us": {
+            "XPU-A": 12.8
+          }
+        },
+        "2": {
+          "description": "(vLLM TP1), MoE routing topk_gating_softmax, tokens=256 experts=128",
+          "init_kwargs": {
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 256,
+            "num_experts": 128
+          },
+          "W_flops": 130816,
+          "Q_bytes": 147456,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.03,
+            "H20": 0.04
+          },
+          "prod_us": {
+            "XPU-A": 13.0
+          }
+        },
+        "3": {
+          "description": "(vLLM TP4), MoE routing topk_gating_softmax, tokens=520 experts=128",
+          "init_kwargs": {
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 520,
+            "num_experts": 128
+          },
+          "W_flops": 265720,
+          "Q_bytes": 299520,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.06,
+            "H20": 0.07
+          },
+          "prod_us": {
+            "XPU-A": 13.0
+          }
+        },
+        "4": {
+          "description": "(vLLM TP4), MoE routing topk_gating_softmax, tokens=1019 experts=128",
+          "init_kwargs": {
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 1019,
+            "num_experts": 128
+          },
+          "W_flops": 520709,
+          "Q_bytes": 586944,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.11,
+            "H20": 0.15
+          },
+          "prod_us": {
+            "XPU-A": 13.1
+          }
+        },
+        "5": {
+          "description": "(vLLM TP4), MoE routing topk_gating_softmax, tokens=2044 experts=128",
+          "init_kwargs": {
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 2044,
+            "num_experts": 128
+          },
+          "W_flops": 1044484,
+          "Q_bytes": 1177344,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.22,
+            "H20": 0.29
+          },
+          "prod_us": {
+            "XPU-A": 13.3
+          }
+        },
+        "6": {
+          "description": "(SGLang TP8), MoE routing topk_gating_softmax, tokens=4083 experts=128",
+          "init_kwargs": {
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 4083,
+            "num_experts": 128
+          },
+          "W_flops": 2086413,
+          "Q_bytes": 2351808,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.44,
+            "H20": 0.59
+          },
+          "prod_us": {
+            "XPU-A": 17.1
+          }
+        },
+        "7": {
+          "description": "(vLLM TP4), MoE routing topk_gating_softmax, tokens=8192 experts=128",
+          "init_kwargs": {
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 8192,
+            "num_experts": 128
+          },
+          "W_flops": 4186112,
+          "Q_bytes": 4718592,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.89,
+            "H20": 1.18
+          },
+          "prod_us": {
+            "XPU-A": 25.6
+          }
+        },
+        "8": {
+          "description": "(vLLM TP inferred), MoE routing topk_softmax, tokens=8037 experts=256",
+          "init_kwargs": {
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 8037,
+            "num_experts": 256
+          },
+          "W_flops": 8221851,
+          "Q_bytes": 8744256,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 1.65,
+            "H20": 2.19
+          },
+          "prod_us": {
+            "XPU-A": 39.4
+          }
+        },
+        "9": {
+          "description": "(vLLM TP inferred), MoE routing topk_softmax, tokens=13526 experts=256",
+          "init_kwargs": {
+            "top_k": 8
+          },
+          "input_kwargs": {
+            "token_count": 13526,
+            "num_experts": 256
+          },
+          "W_flops": 13837098,
+          "Q_bytes": 14716288,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 2.78,
+            "H20": 3.68
+          },
+          "prod_us": {
+            "XPU-A": 56.2
+          }
+        }
+      }
+    },
+    {
+      "name": "fused_qk_rmsnorm",
+      "id": "atrex_010",
+      "dtype": "fp16",
+      "framework": "rtp-llm",
+      "symbol": "fusedQkRmsNorm",
+      "module": "rtp_llm.cpp.kernels.rocm.fused_qk_rmsnorm",
+      "phase": "prefill/decode",
+      "shapes": 4,
+      "importance": 0.018695,
+      "roofline": {
+        "median_ai": 0.7,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 27720,
+          "Q_bytes": 41472,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP1), text decoder fused QK RMSNorm, heads=64/8 head_dim=128"
+        },
+        "1": {
+          "W_flops": 15400,
+          "Q_bytes": 25088,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP1), text decoder fused QK RMSNorm, heads=32/8 head_dim=128"
+        },
+        "3": {
+          "W_flops": 13860,
+          "Q_bytes": 20992,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP2), text decoder fused QK RMSNorm, heads=32/4 head_dim=128"
+        },
+        "4": {
+          "W_flops": 18480,
+          "Q_bytes": 29184,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP1), text decoder fused QK RMSNorm, heads=40/8 head_dim=128"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 4,
+          "median_us": 7.8,
+          "min_us": 7.7,
+          "max_us": 7.8,
+          "framework": "rtp"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 7.7,
+          "1": 7.8,
+          "3": 7.8,
+          "4": 7.7
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self, head_num: int, kv_head_num: int, size_per_head: int=128, eps: float=1e-06) -> None:\n        super().__init__()\n        self.head_num = head_num\n        self.kv_head_num = kv_head_num\n        self.size_per_head = size_per_head\n        self.eps = eps\n        self.q_size = head_num * size_per_head\n        self.kv_size = kv_head_num * size_per_head\n\n    def _rmsnorm(self, x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:\n        input_dtype = x.dtype\n        x = x.to(torch.float32)\n        variance = x.pow(2).mean(-1, keepdim=True)\n        x = x * torch.rsqrt(variance + self.eps)\n        return weight * x.to(input_dtype)\n\n    def forward(self, hidden_states: torch.Tensor, q_weight: torch.Tensor, k_weight: torch.Tensor) -> torch.Tensor:\n        (q, k, v) = hidden_states.split([self.q_size, self.kv_size, self.kv_size], dim=-1)\n        q = self._rmsnorm(q.reshape(-1, self.size_per_head), q_weight).view(q.shape)\n        k = self._rmsnorm(k.reshape(-1, self.size_per_head), k_weight).view(k.shape)\n        return torch.cat([q, k, v], dim=-1)\n",
+      "input_code": "import torch\n\ndef _make_inputs(num_tokens: int, head_num: int, kv_head_num: int, size_per_head: int=128, dtype: str='fp16') -> dict[str, torch.Tensor]:\n    dt = torch.float16 if dtype == 'fp16' else torch.bfloat16\n    hidden_size = head_num * size_per_head + 2 * kv_head_num * size_per_head\n    hidden_states = torch.randn(num_tokens, hidden_size, dtype=dt, device='cuda')\n    q_weight = torch.randn(size_per_head, dtype=dt, device='cuda')\n    k_weight = torch.randn(size_per_head, dtype=dt, device='cuda')\n    return {'hidden_states': hidden_states, 'q_weight': q_weight, 'k_weight': k_weight}\n",
+      "shape_details": {
+        "0": {
+          "description": "(rtp-llm TP1), text decoder fused QK RMSNorm, heads=64/8 head_dim=128",
+          "init_kwargs": {
+            "head_num": 64,
+            "kv_head_num": 8,
+            "size_per_head": 128
+          },
+          "input_kwargs": {
+            "num_tokens": 1,
+            "head_num": 64,
+            "kv_head_num": 8,
+            "size_per_head": 128,
+            "dtype": "fp16"
+          },
+          "W_flops": 27720,
+          "Q_bytes": 41472,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 7.7
+          }
+        },
+        "1": {
+          "description": "(rtp-llm TP1), text decoder fused QK RMSNorm, heads=32/8 head_dim=128",
+          "init_kwargs": {
+            "head_num": 32,
+            "kv_head_num": 8,
+            "size_per_head": 128
+          },
+          "input_kwargs": {
+            "num_tokens": 1,
+            "head_num": 32,
+            "kv_head_num": 8,
+            "size_per_head": 128,
+            "dtype": "fp16"
+          },
+          "W_flops": 15400,
+          "Q_bytes": 25088,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 7.8
+          }
+        },
+        "3": {
+          "description": "(rtp-llm TP2), text decoder fused QK RMSNorm, heads=32/4 head_dim=128",
+          "init_kwargs": {
+            "head_num": 32,
+            "kv_head_num": 4,
+            "size_per_head": 128
+          },
+          "input_kwargs": {
+            "num_tokens": 1,
+            "head_num": 32,
+            "kv_head_num": 4,
+            "size_per_head": 128,
+            "dtype": "fp16"
+          },
+          "W_flops": 13860,
+          "Q_bytes": 20992,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 7.8
+          }
+        },
+        "4": {
+          "description": "(rtp-llm TP1), text decoder fused QK RMSNorm, heads=40/8 head_dim=128",
+          "init_kwargs": {
+            "head_num": 40,
+            "kv_head_num": 8,
+            "size_per_head": 128
+          },
+          "input_kwargs": {
+            "num_tokens": 1,
+            "head_num": 40,
+            "kv_head_num": 8,
+            "size_per_head": 128,
+            "dtype": "fp16"
+          },
+          "W_flops": 18480,
+          "Q_bytes": 29184,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 7.7
+          }
+        }
+      }
+    },
+    {
+      "name": "silu_and_mul",
+      "id": "atrex_028",
+      "dtype": "bf16",
+      "framework": "vllm",
+      "symbol": "vllm_silu_and_mul",
+      "module": "vllm._C.silu_and_mul / csrc/activation_kernels.cu",
+      "phase": "prefill/decode",
+      "shapes": 37,
+      "importance": 0.017601,
+      "roofline": {
+        "median_ai": 0.8,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 3840,
+          "Q_bytes": 4608,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(rtp-llm TP1), text decoder MoE expert gated SiLU, shape=(1,1536)"
+        },
+        "1": {
+          "W_flops": 6259200,
+          "Q_bytes": 7511040,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.42,
+            "H20": 1.88
+          },
+          "description": "(SGLang TP1), text decoder gated SiLU activation, shape=(1630,1536)"
+        },
+        "2": {
+          "W_flops": 18001920,
+          "Q_bytes": 21602304,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 4.08,
+            "H20": 5.4
+          },
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(4688,1536)"
+        },
+        "3": {
+          "W_flops": 41103360,
+          "Q_bytes": 49324032,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 9.31,
+            "H20": 12.33
+          },
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(10704,1536)"
+        },
+        "4": {
+          "W_flops": 61532160,
+          "Q_bytes": 73838592,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 13.93,
+            "H20": 18.46
+          },
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(16024,1536)"
+        },
+        "5": {
+          "W_flops": 94679040,
+          "Q_bytes": 113614848,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 21.44,
+            "H20": 28.4
+          },
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(24656,1536)"
+        },
+        "6": {
+          "W_flops": 188282880,
+          "Q_bytes": 225939456,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 42.63,
+            "H20": 56.48
+          },
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(49032,1536)"
+        },
+        "7": {
+          "W_flops": 493946880,
+          "Q_bytes": 592736256,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 111.84,
+            "H20": 148.18
+          },
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(128632,1536)"
+        },
+        "8": {
+          "W_flops": 674611200,
+          "Q_bytes": 809533440,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 152.74,
+            "H20": 202.38
+          },
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(175680,1536)"
+        },
+        "9": {
+          "W_flops": 5120,
+          "Q_bytes": 6144,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(1,2048)"
+        },
+        "10": {
+          "W_flops": 936960,
+          "Q_bytes": 1124352,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.21,
+            "H20": 0.28
+          },
+          "description": "(sglang TP1), text decoder gated SiLU, shape=(183,2048)"
+        },
+        "11": {
+          "W_flops": 5698560,
+          "Q_bytes": 6838272,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.29,
+            "H20": 1.71
+          },
+          "description": "(sglang TP1), text decoder gated SiLU, shape=(1113,2048)"
+        },
+        "12": {
+          "W_flops": 6400,
+          "Q_bytes": 7680,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(1,2560)"
+        },
+        "13": {
+          "W_flops": 13332480,
+          "Q_bytes": 15998976,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 3.02,
+            "H20": 4.0
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(1736,3072)"
+        },
+        "14": {
+          "W_flops": 38400000,
+          "Q_bytes": 46080000,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 8.69,
+            "H20": 11.52
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(5000,3072)"
+        },
+        "15": {
+          "W_flops": 88857600,
+          "Q_bytes": 106629120,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 20.12,
+            "H20": 26.66
+          },
+          "description": "(vLLM TP4), text decoder gated SiLU activation, shape=(11570,3072)"
+        },
+        "16": {
+          "W_flops": 109977600,
+          "Q_bytes": 131973120,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 24.9,
+            "H20": 32.99
+          },
+          "description": "(vLLM TP4), text decoder gated SiLU activation, shape=(14320,3072)"
+        },
+        "17": {
+          "W_flops": 1310720,
+          "Q_bytes": 1572864,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.3,
+            "H20": 0.39
+          },
+          "description": "(SGLang), gated SiLU activation, shape=(128,4096)"
+        },
+        "18": {
+          "W_flops": 2621440,
+          "Q_bytes": 3145728,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.59,
+            "H20": 0.79
+          },
+          "description": "(SGLang), gated SiLU activation, shape=(256,4096)"
+        },
+        "19": {
+          "W_flops": 5242880,
+          "Q_bytes": 6291456,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.19,
+            "H20": 1.57
+          },
+          "description": "(SGLang), gated SiLU activation, shape=(512,4096)"
+        },
+        "20": {
+          "W_flops": 10475520,
+          "Q_bytes": 12570624,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 2.37,
+            "H20": 3.14
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(1023,4096)"
+        },
+        "21": {
+          "W_flops": 20930560,
+          "Q_bytes": 25116672,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 4.74,
+            "H20": 6.28
+          },
+          "description": "(vLLM TP4), text decoder gated SiLU activation, shape=(2044,4096)"
+        },
+        "22": {
+          "W_flops": 41912320,
+          "Q_bytes": 50294784,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 9.49,
+            "H20": 12.57
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(4093,4096)"
+        },
+        "23": {
+          "W_flops": 83886080,
+          "Q_bytes": 100663296,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 18.99,
+            "H20": 25.17
+          },
+          "description": "(vLLM TP4), text decoder gated SiLU activation, shape=(8192,4096)"
+        },
+        "24": {
+          "W_flops": 168120320,
+          "Q_bytes": 201744384,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 38.06,
+            "H20": 50.44
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(16418,4096)"
+        },
+        "25": {
+          "W_flops": 210309120,
+          "Q_bytes": 252370944,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 47.62,
+            "H20": 63.09
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(20538,4096)"
+        },
+        "26": {
+          "W_flops": 6758400,
+          "Q_bytes": 8110080,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.53,
+            "H20": 2.03
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(528,5120)"
+        },
+        "27": {
+          "W_flops": 13516800,
+          "Q_bytes": 16220160,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 3.06,
+            "H20": 4.06
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(1056,5120)"
+        },
+        "28": {
+          "W_flops": 24448000,
+          "Q_bytes": 29337600,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 5.54,
+            "H20": 7.33
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(1910,5120)"
+        },
+        "29": {
+          "W_flops": 53465600,
+          "Q_bytes": 64158720,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 12.11,
+            "H20": 16.04
+          },
+          "description": "(SGLang), gated SiLU activation, shape=(4177,5120)"
+        },
+        "30": {
+          "W_flops": 104857600,
+          "Q_bytes": 125829120,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 23.74,
+            "H20": 31.46
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(8192,5120)"
+        },
+        "31": {
+          "W_flops": 11059200,
+          "Q_bytes": 13271040,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 2.5,
+            "H20": 3.32
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(540,8192)"
+        },
+        "32": {
+          "W_flops": 20541440,
+          "Q_bytes": 24649728,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 4.65,
+            "H20": 6.16
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(1003,8192)"
+        },
+        "33": {
+          "W_flops": 41902080,
+          "Q_bytes": 50282496,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 9.49,
+            "H20": 12.57
+          },
+          "description": "(vLLM), gated SiLU activation, shape=(2046,8192)"
+        },
+        "34": {
+          "W_flops": 83927040,
+          "Q_bytes": 100712448,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 19.0,
+            "H20": 25.18
+          },
+          "description": "(SGLang), gated SiLU activation, shape=(4098,8192)"
+        },
+        "35": {
+          "W_flops": 167505920,
+          "Q_bytes": 201007104,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 37.93,
+            "H20": 50.25
+          },
+          "description": "(SGLang), gated SiLU activation, shape=(8179,8192)"
+        },
+        "36": {
+          "W_flops": 315002880,
+          "Q_bytes": 378003456,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 71.32,
+            "H20": 94.5
+          },
+          "description": "(SGLang), gated SiLU activation, shape=(15381,8192)"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 37,
+          "median_us": 31.4,
+          "min_us": 7.5,
+          "max_us": 490.7,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 7.6,
+          "1": 12.2,
+          "2": 21.2,
+          "3": 38.1,
+          "4": 52.6,
+          "5": 76.2,
+          "6": 143.8,
+          "7": 362.7,
+          "8": 490.7,
+          "9": 7.5,
+          "10": 7.7,
+          "11": 9.3,
+          "12": 7.5,
+          "13": 15.2,
+          "14": 31.4,
+          "15": 63.2,
+          "16": 102.2,
+          "17": 7.7,
+          "18": 8.0,
+          "19": 9.1,
+          "20": 12.5,
+          "21": 19.5,
+          "22": 33.1,
+          "23": 58.3,
+          "24": 109.6,
+          "25": 135.7,
+          "26": 12.3,
+          "27": 19.4,
+          "28": 29.5,
+          "29": 57.0,
+          "30": 105.1,
+          "31": 12.9,
+          "32": 19.4,
+          "33": 33.2,
+          "34": 58.9,
+          "35": 110.8,
+          "36": 202.6
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self) -> None:\n        super().__init__()\n\n    def forward(self, x: torch.Tensor) -> torch.Tensor:\n        if x.shape[-1] >= 2:\n            split = x.shape[-1] // 2\n            gate = x[..., :split]\n            up = x[..., split:split + split]\n            activated = F.silu(gate.float()).to(x.dtype)\n            return (activated * up).to(x.dtype)\n        return F.silu(x.float()).to(x.dtype)\n",
+      "input_code": "import torch\n\ndef _make_inputs(shape: list[int]) -> dict[str, torch.Tensor]:\n    tensor_shape = tuple((int(dim) for dim in shape))\n    if len(tensor_shape) == 0:\n        tensor_shape = (1,)\n    x = torch.randn(tensor_shape, dtype=torch.bfloat16, device='cuda')\n    return {'x': x}\n",
+      "shape_details": {
+        "0": {
+          "description": "(rtp-llm TP1), text decoder MoE expert gated SiLU, shape=(1,1536)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1,
+              1536
+            ]
+          },
+          "W_flops": 3840,
+          "Q_bytes": 4608,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 7.6
+          }
+        },
+        "1": {
+          "description": "(SGLang TP1), text decoder gated SiLU activation, shape=(1630,1536)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1630,
+              1536
+            ]
+          },
+          "W_flops": 6259200,
+          "Q_bytes": 7511040,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.42,
+            "H20": 1.88
+          },
+          "prod_us": {
+            "XPU-A": 12.2
+          }
+        },
+        "2": {
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(4688,1536)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              4688,
+              1536
+            ]
+          },
+          "W_flops": 18001920,
+          "Q_bytes": 21602304,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 4.08,
+            "H20": 5.4
+          },
+          "prod_us": {
+            "XPU-A": 21.2
+          }
+        },
+        "3": {
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(10704,1536)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              10704,
+              1536
+            ]
+          },
+          "W_flops": 41103360,
+          "Q_bytes": 49324032,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 9.31,
+            "H20": 12.33
+          },
+          "prod_us": {
+            "XPU-A": 38.1
+          }
+        },
+        "4": {
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(16024,1536)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              16024,
+              1536
+            ]
+          },
+          "W_flops": 61532160,
+          "Q_bytes": 73838592,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 13.93,
+            "H20": 18.46
+          },
+          "prod_us": {
+            "XPU-A": 52.6
+          }
+        },
+        "5": {
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(24656,1536)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              24656,
+              1536
+            ]
+          },
+          "W_flops": 94679040,
+          "Q_bytes": 113614848,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 21.44,
+            "H20": 28.4
+          },
+          "prod_us": {
+            "XPU-A": 76.2
+          }
+        },
+        "6": {
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(49032,1536)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              49032,
+              1536
+            ]
+          },
+          "W_flops": 188282880,
+          "Q_bytes": 225939456,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 42.63,
+            "H20": 56.48
+          },
+          "prod_us": {
+            "XPU-A": 143.8
+          }
+        },
+        "7": {
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(128632,1536)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              128632,
+              1536
+            ]
+          },
+          "W_flops": 493946880,
+          "Q_bytes": 592736256,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 111.84,
+            "H20": 148.18
+          },
+          "prod_us": {
+            "XPU-A": 362.7
+          }
+        },
+        "8": {
+          "description": "(vLLM TP1), text decoder gated SiLU activation, shape=(175680,1536)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              175680,
+              1536
+            ]
+          },
+          "W_flops": 674611200,
+          "Q_bytes": 809533440,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 152.74,
+            "H20": 202.38
+          },
+          "prod_us": {
+            "XPU-A": 490.7
+          }
+        },
+        "9": {
+          "description": "(vLLM), gated SiLU activation, shape=(1,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1,
+              2048
+            ]
+          },
+          "W_flops": 5120,
+          "Q_bytes": 6144,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 7.5
+          }
+        },
+        "10": {
+          "description": "(sglang TP1), text decoder gated SiLU, shape=(183,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              183,
+              2048
+            ]
+          },
+          "W_flops": 936960,
+          "Q_bytes": 1124352,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.21,
+            "H20": 0.28
+          },
+          "prod_us": {
+            "XPU-A": 7.7
+          }
+        },
+        "11": {
+          "description": "(sglang TP1), text decoder gated SiLU, shape=(1113,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1113,
+              2048
+            ]
+          },
+          "W_flops": 5698560,
+          "Q_bytes": 6838272,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.29,
+            "H20": 1.71
+          },
+          "prod_us": {
+            "XPU-A": 9.3
+          }
+        },
+        "12": {
+          "description": "(vLLM), gated SiLU activation, shape=(1,2560)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1,
+              2560
+            ]
+          },
+          "W_flops": 6400,
+          "Q_bytes": 7680,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 7.5
+          }
+        },
+        "13": {
+          "description": "(vLLM), gated SiLU activation, shape=(1736,3072)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1736,
+              3072
+            ]
+          },
+          "W_flops": 13332480,
+          "Q_bytes": 15998976,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 3.02,
+            "H20": 4.0
+          },
+          "prod_us": {
+            "XPU-A": 15.2
+          }
+        },
+        "14": {
+          "description": "(vLLM), gated SiLU activation, shape=(5000,3072)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              5000,
+              3072
+            ]
+          },
+          "W_flops": 38400000,
+          "Q_bytes": 46080000,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 8.69,
+            "H20": 11.52
+          },
+          "prod_us": {
+            "XPU-A": 31.4
+          }
+        },
+        "15": {
+          "description": "(vLLM TP4), text decoder gated SiLU activation, shape=(11570,3072)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              11570,
+              3072
+            ]
+          },
+          "W_flops": 88857600,
+          "Q_bytes": 106629120,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 20.12,
+            "H20": 26.66
+          },
+          "prod_us": {
+            "XPU-A": 63.2
+          }
+        },
+        "16": {
+          "description": "(vLLM TP4), text decoder gated SiLU activation, shape=(14320,3072)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              14320,
+              3072
+            ]
+          },
+          "W_flops": 109977600,
+          "Q_bytes": 131973120,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 24.9,
+            "H20": 32.99
+          },
+          "prod_us": {
+            "XPU-A": 102.2
+          }
+        },
+        "17": {
+          "description": "(SGLang), gated SiLU activation, shape=(128,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              128,
+              4096
+            ]
+          },
+          "W_flops": 1310720,
+          "Q_bytes": 1572864,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.3,
+            "H20": 0.39
+          },
+          "prod_us": {
+            "XPU-A": 7.7
+          }
+        },
+        "18": {
+          "description": "(SGLang), gated SiLU activation, shape=(256,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              256,
+              4096
+            ]
+          },
+          "W_flops": 2621440,
+          "Q_bytes": 3145728,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.59,
+            "H20": 0.79
+          },
+          "prod_us": {
+            "XPU-A": 8.0
+          }
+        },
+        "19": {
+          "description": "(SGLang), gated SiLU activation, shape=(512,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              512,
+              4096
+            ]
+          },
+          "W_flops": 5242880,
+          "Q_bytes": 6291456,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.19,
+            "H20": 1.57
+          },
+          "prod_us": {
+            "XPU-A": 9.1
+          }
+        },
+        "20": {
+          "description": "(vLLM), gated SiLU activation, shape=(1023,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1023,
+              4096
+            ]
+          },
+          "W_flops": 10475520,
+          "Q_bytes": 12570624,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 2.37,
+            "H20": 3.14
+          },
+          "prod_us": {
+            "XPU-A": 12.5
+          }
+        },
+        "21": {
+          "description": "(vLLM TP4), text decoder gated SiLU activation, shape=(2044,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              2044,
+              4096
+            ]
+          },
+          "W_flops": 20930560,
+          "Q_bytes": 25116672,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 4.74,
+            "H20": 6.28
+          },
+          "prod_us": {
+            "XPU-A": 19.5
+          }
+        },
+        "22": {
+          "description": "(vLLM), gated SiLU activation, shape=(4093,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              4093,
+              4096
+            ]
+          },
+          "W_flops": 41912320,
+          "Q_bytes": 50294784,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 9.49,
+            "H20": 12.57
+          },
+          "prod_us": {
+            "XPU-A": 33.1
+          }
+        },
+        "23": {
+          "description": "(vLLM TP4), text decoder gated SiLU activation, shape=(8192,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              8192,
+              4096
+            ]
+          },
+          "W_flops": 83886080,
+          "Q_bytes": 100663296,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 18.99,
+            "H20": 25.17
+          },
+          "prod_us": {
+            "XPU-A": 58.3
+          }
+        },
+        "24": {
+          "description": "(vLLM), gated SiLU activation, shape=(16418,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              16418,
+              4096
+            ]
+          },
+          "W_flops": 168120320,
+          "Q_bytes": 201744384,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 38.06,
+            "H20": 50.44
+          },
+          "prod_us": {
+            "XPU-A": 109.6
+          }
+        },
+        "25": {
+          "description": "(vLLM), gated SiLU activation, shape=(20538,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              20538,
+              4096
+            ]
+          },
+          "W_flops": 210309120,
+          "Q_bytes": 252370944,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 47.62,
+            "H20": 63.09
+          },
+          "prod_us": {
+            "XPU-A": 135.7
+          }
+        },
+        "26": {
+          "description": "(vLLM), gated SiLU activation, shape=(528,5120)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              528,
+              5120
+            ]
+          },
+          "W_flops": 6758400,
+          "Q_bytes": 8110080,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.53,
+            "H20": 2.03
+          },
+          "prod_us": {
+            "XPU-A": 12.3
+          }
+        },
+        "27": {
+          "description": "(vLLM), gated SiLU activation, shape=(1056,5120)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1056,
+              5120
+            ]
+          },
+          "W_flops": 13516800,
+          "Q_bytes": 16220160,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 3.06,
+            "H20": 4.06
+          },
+          "prod_us": {
+            "XPU-A": 19.4
+          }
+        },
+        "28": {
+          "description": "(vLLM), gated SiLU activation, shape=(1910,5120)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1910,
+              5120
+            ]
+          },
+          "W_flops": 24448000,
+          "Q_bytes": 29337600,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 5.54,
+            "H20": 7.33
+          },
+          "prod_us": {
+            "XPU-A": 29.5
+          }
+        },
+        "29": {
+          "description": "(SGLang), gated SiLU activation, shape=(4177,5120)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              4177,
+              5120
+            ]
+          },
+          "W_flops": 53465600,
+          "Q_bytes": 64158720,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 12.11,
+            "H20": 16.04
+          },
+          "prod_us": {
+            "XPU-A": 57.0
+          }
+        },
+        "30": {
+          "description": "(vLLM), gated SiLU activation, shape=(8192,5120)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              8192,
+              5120
+            ]
+          },
+          "W_flops": 104857600,
+          "Q_bytes": 125829120,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 23.74,
+            "H20": 31.46
+          },
+          "prod_us": {
+            "XPU-A": 105.1
+          }
+        },
+        "31": {
+          "description": "(vLLM), gated SiLU activation, shape=(540,8192)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              540,
+              8192
+            ]
+          },
+          "W_flops": 11059200,
+          "Q_bytes": 13271040,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 2.5,
+            "H20": 3.32
+          },
+          "prod_us": {
+            "XPU-A": 12.9
+          }
+        },
+        "32": {
+          "description": "(vLLM), gated SiLU activation, shape=(1003,8192)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1003,
+              8192
+            ]
+          },
+          "W_flops": 20541440,
+          "Q_bytes": 24649728,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 4.65,
+            "H20": 6.16
+          },
+          "prod_us": {
+            "XPU-A": 19.4
+          }
+        },
+        "33": {
+          "description": "(vLLM), gated SiLU activation, shape=(2046,8192)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              2046,
+              8192
+            ]
+          },
+          "W_flops": 41902080,
+          "Q_bytes": 50282496,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 9.49,
+            "H20": 12.57
+          },
+          "prod_us": {
+            "XPU-A": 33.2
+          }
+        },
+        "34": {
+          "description": "(SGLang), gated SiLU activation, shape=(4098,8192)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              4098,
+              8192
+            ]
+          },
+          "W_flops": 83927040,
+          "Q_bytes": 100712448,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 19.0,
+            "H20": 25.18
+          },
+          "prod_us": {
+            "XPU-A": 58.9
+          }
+        },
+        "35": {
+          "description": "(SGLang), gated SiLU activation, shape=(8179,8192)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              8179,
+              8192
+            ]
+          },
+          "W_flops": 167505920,
+          "Q_bytes": 201007104,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 37.93,
+            "H20": 50.25
+          },
+          "prod_us": {
+            "XPU-A": 110.8
+          }
+        },
+        "36": {
+          "description": "(SGLang), gated SiLU activation, shape=(15381,8192)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              15381,
+              8192
+            ]
+          },
+          "W_flops": 315002880,
+          "Q_bytes": 378003456,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 71.32,
+            "H20": 94.5
+          },
+          "prod_us": {
+            "XPU-A": 202.6
+          }
+        }
+      }
+    },
+    {
+      "name": "chunk_gated_delta_rule_state",
+      "id": "atrex_005",
+      "dtype": "bf16",
+      "framework": "sglang",
+      "symbol": "chunk_gated_delta_rule_fwd_h",
+      "module": "sglang.srt.layers.attention.fla.chunk_delta_h",
+      "phase": "prefill",
+      "shapes": 25,
+      "importance": 0.015735,
+      "roofline": {
+        "median_ai": 44.9,
+        "regime": "compute-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 271585280,
+          "Q_bytes": 6045700,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 1.17,
+            "H20": 1.84
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=1/2 dim=128/128"
+        },
+        "1": {
+          "W_flops": 2715852800,
+          "Q_bytes": 60456964,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 11.67,
+            "H20": 18.35
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=10/20 dim=128/128"
+        },
+        "2": {
+          "W_flops": 2987438080,
+          "Q_bytes": 66502660,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 12.84,
+            "H20": 20.19
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=11/22 dim=128/128"
+        },
+        "3": {
+          "W_flops": 3259023360,
+          "Q_bytes": 72548356,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 14.01,
+            "H20": 22.02
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=12/24 dim=128/128"
+        },
+        "4": {
+          "W_flops": 3530608640,
+          "Q_bytes": 78594052,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 15.18,
+            "H20": 23.86
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=13/26 dim=128/128"
+        },
+        "5": {
+          "W_flops": 3802193920,
+          "Q_bytes": 84639748,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 16.34,
+            "H20": 25.69
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=14/28 dim=128/128"
+        },
+        "6": {
+          "W_flops": 4073779200,
+          "Q_bytes": 90685444,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 17.51,
+            "H20": 27.53
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=15/30 dim=128/128"
+        },
+        "7": {
+          "W_flops": 4345364480,
+          "Q_bytes": 96731140,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 18.68,
+            "H20": 29.36
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=16/32 dim=128/128"
+        },
+        "8": {
+          "W_flops": 543170560,
+          "Q_bytes": 12091396,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 2.33,
+            "H20": 3.67
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=2/4 dim=128/128"
+        },
+        "9": {
+          "W_flops": 1086341120,
+          "Q_bytes": 23658500,
+          "ai": 45.9,
+          "SOL_time_ms": {
+            "XPU-A": 4.67,
+            "H20": 7.34
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=4096 heads=2/4 dim=128/128"
+        },
+        "10": {
+          "W_flops": 2172682240,
+          "Q_bytes": 46792708,
+          "ai": 46.4,
+          "SOL_time_ms": {
+            "XPU-A": 9.34,
+            "H20": 14.68
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=8192 heads=2/4 dim=128/128"
+        },
+        "11": {
+          "W_flops": 4345364480,
+          "Q_bytes": 93061124,
+          "ai": 46.7,
+          "SOL_time_ms": {
+            "XPU-A": 18.68,
+            "H20": 29.36
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=16384 heads=2/4 dim=128/128"
+        },
+        "12": {
+          "W_flops": 6518046720,
+          "Q_bytes": 139329540,
+          "ai": 46.8,
+          "SOL_time_ms": {
+            "XPU-A": 28.02,
+            "H20": 44.04
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=24576 heads=2/4 dim=128/128"
+        },
+        "13": {
+          "W_flops": 814755840,
+          "Q_bytes": 18137092,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 3.5,
+            "H20": 5.51
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=3/6 dim=128/128"
+        },
+        "14": {
+          "W_flops": 271585280,
+          "Q_bytes": 6832132,
+          "ai": 39.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.29,
+            "H20": 1.84
+          },
+          "description": "(vLLM TP4), chunk state update, tokens=512 heads=4/8 dim=128/128"
+        },
+        "15": {
+          "W_flops": 543170560,
+          "Q_bytes": 12615684,
+          "ai": 43.1,
+          "SOL_time_ms": {
+            "XPU-A": 2.38,
+            "H20": 3.67
+          },
+          "description": "(vLLM TP4), chunk state update, tokens=1024 heads=4/8 dim=128/128"
+        },
+        "16": {
+          "W_flops": 1086341120,
+          "Q_bytes": 24182788,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 4.67,
+            "H20": 7.34
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=4/8 dim=128/128"
+        },
+        "17": {
+          "W_flops": 1357926400,
+          "Q_bytes": 30228484,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 5.84,
+            "H20": 9.18
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=5/10 dim=128/128"
+        },
+        "18": {
+          "W_flops": 1629511680,
+          "Q_bytes": 36274180,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 7.0,
+            "H20": 11.01
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=6/12 dim=128/128"
+        },
+        "19": {
+          "W_flops": 1901096960,
+          "Q_bytes": 42319876,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 8.17,
+            "H20": 12.85
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=7/14 dim=128/128"
+        },
+        "20": {
+          "W_flops": 1086341120,
+          "Q_bytes": 25231364,
+          "ai": 43.1,
+          "SOL_time_ms": {
+            "XPU-A": 4.76,
+            "H20": 7.34
+          },
+          "description": "(SGLang TP8), chunk state update, tokens=1024 heads=8/16 dim=128/128"
+        },
+        "21": {
+          "W_flops": 2172682240,
+          "Q_bytes": 48365572,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 9.34,
+            "H20": 14.68
+          },
+          "description": "(SGLang TP8), chunk state update, tokens=2048 heads=8/16 dim=128/128"
+        },
+        "22": {
+          "W_flops": 2444267520,
+          "Q_bytes": 54411268,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 10.51,
+            "H20": 16.52
+          },
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=9/18 dim=128/128"
+        },
+        "23": {
+          "W_flops": 8901258336,
+          "Q_bytes": 194216324,
+          "ai": 45.8,
+          "SOL_time_ms": {
+            "XPU-A": 38.26,
+            "H20": 60.14
+          },
+          "description": "(SGLang/vLLM), chunk state update, tokens=4195 heads=16/32 dim=128/128"
+        },
+        "24": {
+          "W_flops": 23397384800,
+          "Q_bytes": 503175556,
+          "ai": 46.5,
+          "SOL_time_ms": {
+            "XPU-A": 100.57,
+            "H20": 158.09
+          },
+          "description": "(SGLang/vLLM), chunk state update, tokens=11027 heads=16/32 dim=128/128"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 25,
+          "median_us": 184.8,
+          "min_us": 32.2,
+          "max_us": 2352.4,
+          "framework": "sglang"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 93.2,
+          "1": 184.8,
+          "2": 269.8,
+          "3": 290.5,
+          "4": 284.6,
+          "5": 293.6,
+          "6": 293.2,
+          "7": 416.0,
+          "8": 95.0,
+          "9": 179.0,
+          "10": 348.4,
+          "11": 767.6,
+          "12": 1203.7,
+          "13": 94.2,
+          "14": 32.2,
+          "15": 54.1,
+          "16": 97.1,
+          "17": 95.7,
+          "18": 184.3,
+          "19": 181.9,
+          "20": 101.6,
+          "21": 188.4,
+          "22": 182.6,
+          "23": 899.5,
+          "24": 2352.4
+        }
+      },
+      "reference_code": "import math\nimport torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self, chunk_size: int=64) -> None:\n        super().__init__()\n        self.chunk_size = int(chunk_size)\n\n    def forward(self, k: torch.Tensor, w: torch.Tensor, u: torch.Tensor, g: torch.Tensor, initial_state: torch.Tensor, initial_state_indices: torch.Tensor) -> dict[str, torch.Tensor]:\n        (batch, tokens, num_k_heads, key_dim) = k.shape\n        (num_heads, value_dim) = (u.shape[2], u.shape[3])\n        heads_per_k = max(num_heads // num_k_heads, 1)\n        cs = self.chunk_size\n        num_chunks = math.ceil(tokens / cs)\n        head_to_khead = torch.tensor([min(hd // heads_per_k, num_k_heads - 1) for hd in range(num_heads)], dtype=torch.long, device=k.device)\n        k_h = k.index_select(2, head_to_khead)\n        final_state = initial_state.float().clone()\n        idx_list = initial_state_indices.tolist()\n        state_indices = torch.tensor(idx_list, dtype=torch.long, device=k.device)\n        h = final_state.index_select(0, state_indices).clone()\n        h_chunks = torch.empty(batch, num_chunks, num_heads, key_dim, value_dim, dtype=k.dtype, device=k.device)\n        v_new = torch.empty_like(u)\n        BH = batch * num_heads\n        h_flat = h.reshape(BH, key_dim, value_dim)\n        for chunk_idx in range(num_chunks):\n            start = chunk_idx * cs\n            end = min(start + cs, tokens)\n            cur_cs = end - start\n            h_chunks[:, chunk_idx] = h_flat.reshape(batch, num_heads, key_dim, value_dim).to(k.dtype)\n            w_blk = w[:, start:end].float()\n            u_blk = u[:, start:end].float()\n            k_blk = k_h[:, start:end].float()\n            g_blk = g[:, start:end].float()\n            w_bh = w_blk.permute(0, 2, 1, 3).reshape(BH, cur_cs, key_dim)\n            u_bh = u_blk.permute(0, 2, 1, 3).reshape(BH, cur_cs, value_dim)\n            k_bh = k_blk.permute(0, 2, 1, 3).reshape(BH, cur_cs, key_dim)\n            g_bh = g_blk.permute(0, 2, 1).reshape(BH, cur_cs)\n            v_blk = u_bh - torch.bmm(w_bh.to(k.dtype).float(), h_flat.to(k.dtype).float())\n            v_blk_out = v_blk.reshape(batch, num_heads, cur_cs, value_dim).permute(0, 2, 1, 3)\n            v_new[:, start:end] = v_blk_out.to(u.dtype)\n            g_last = g_bh[:, -1:]\n            g_diff = g_last - g_bh\n            v_blk_scaled = v_blk * torch.exp(torch.where(g_diff <= 0, g_diff, torch.tensor(float('-inf'), device=g_diff.device))).unsqueeze(-1)\n            v_blk_scaled = v_blk_scaled.to(k.dtype)\n            h_flat = h_flat * torch.exp(g_last).unsqueeze(-1)\n            h_flat = h_flat + torch.bmm(k_bh.to(k.dtype).transpose(-2, -1).float(), v_blk_scaled.float())\n        h_back = h_flat.reshape(batch, num_heads, key_dim, value_dim)\n        final_state.index_copy_(0, state_indices, h_back)\n        return {'h': h_chunks, 'v_new': v_new, 'final_state': final_state}\n",
+      "input_code": "import torch\n\ndef _make_inputs(batch_size: int, token_count: int, num_k_heads: int, num_v_heads: int, key_dim: int, value_dim: int, state_count: int) -> dict[str, torch.Tensor]:\n    k = torch.randn(batch_size, token_count, num_k_heads, key_dim, dtype=torch.bfloat16, device='cuda') * 0.02\n    w = torch.randn(batch_size, token_count, num_v_heads, key_dim, dtype=torch.bfloat16, device='cuda') * 0.02\n    u = torch.randn(batch_size, token_count, num_v_heads, value_dim, dtype=torch.bfloat16, device='cuda') * 0.02\n    g = -torch.rand(batch_size, token_count, num_v_heads, dtype=torch.float32, device='cuda')\n    initial_state = torch.randn(state_count, num_v_heads, key_dim, value_dim, dtype=torch.float32, device='cuda') * 0.02\n    initial_state_indices = torch.arange(batch_size, dtype=torch.int32, device='cuda') % state_count\n    return {'k': k, 'w': w, 'u': u, 'g': g, 'initial_state': initial_state, 'initial_state_indices': initial_state_indices}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=1/2 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 2,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 1,
+            "batch_size": 1
+          },
+          "W_flops": 271585280,
+          "Q_bytes": 6045700,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 1.17,
+            "H20": 1.84
+          },
+          "prod_us": {
+            "XPU-A": 93.2
+          }
+        },
+        "1": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=10/20 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 20,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 10,
+            "batch_size": 1
+          },
+          "W_flops": 2715852800,
+          "Q_bytes": 60456964,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 11.67,
+            "H20": 18.35
+          },
+          "prod_us": {
+            "XPU-A": 184.8
+          }
+        },
+        "2": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=11/22 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 22,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 11,
+            "batch_size": 1
+          },
+          "W_flops": 2987438080,
+          "Q_bytes": 66502660,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 12.84,
+            "H20": 20.19
+          },
+          "prod_us": {
+            "XPU-A": 269.8
+          }
+        },
+        "3": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=12/24 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 24,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 12,
+            "batch_size": 1
+          },
+          "W_flops": 3259023360,
+          "Q_bytes": 72548356,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 14.01,
+            "H20": 22.02
+          },
+          "prod_us": {
+            "XPU-A": 290.5
+          }
+        },
+        "4": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=13/26 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 26,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 13,
+            "batch_size": 1
+          },
+          "W_flops": 3530608640,
+          "Q_bytes": 78594052,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 15.18,
+            "H20": 23.86
+          },
+          "prod_us": {
+            "XPU-A": 284.6
+          }
+        },
+        "5": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=14/28 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 28,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 14,
+            "batch_size": 1
+          },
+          "W_flops": 3802193920,
+          "Q_bytes": 84639748,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 16.34,
+            "H20": 25.69
+          },
+          "prod_us": {
+            "XPU-A": 293.6
+          }
+        },
+        "6": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=15/30 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 30,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 15,
+            "batch_size": 1
+          },
+          "W_flops": 4073779200,
+          "Q_bytes": 90685444,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 17.51,
+            "H20": 27.53
+          },
+          "prod_us": {
+            "XPU-A": 293.2
+          }
+        },
+        "7": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 32,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 16,
+            "batch_size": 1
+          },
+          "W_flops": 4345364480,
+          "Q_bytes": 96731140,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 18.68,
+            "H20": 29.36
+          },
+          "prod_us": {
+            "XPU-A": 416.0
+          }
+        },
+        "8": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=2/4 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 4,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 2,
+            "batch_size": 1
+          },
+          "W_flops": 543170560,
+          "Q_bytes": 12091396,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 2.33,
+            "H20": 3.67
+          },
+          "prod_us": {
+            "XPU-A": 95.0
+          }
+        },
+        "9": {
+          "description": "(vLLM TP1), chunk state update, tokens=4096 heads=2/4 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 4096,
+            "num_v_heads": 4,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 2,
+            "batch_size": 1
+          },
+          "W_flops": 1086341120,
+          "Q_bytes": 23658500,
+          "ai": 45.9,
+          "SOL_time_ms": {
+            "XPU-A": 4.67,
+            "H20": 7.34
+          },
+          "prod_us": {
+            "XPU-A": 179.0
+          }
+        },
+        "10": {
+          "description": "(vLLM TP1), chunk state update, tokens=8192 heads=2/4 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 8192,
+            "num_v_heads": 4,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 2,
+            "batch_size": 1
+          },
+          "W_flops": 2172682240,
+          "Q_bytes": 46792708,
+          "ai": 46.4,
+          "SOL_time_ms": {
+            "XPU-A": 9.34,
+            "H20": 14.68
+          },
+          "prod_us": {
+            "XPU-A": 348.4
+          }
+        },
+        "11": {
+          "description": "(vLLM TP1), chunk state update, tokens=16384 heads=2/4 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 16384,
+            "num_v_heads": 4,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 2,
+            "batch_size": 1
+          },
+          "W_flops": 4345364480,
+          "Q_bytes": 93061124,
+          "ai": 46.7,
+          "SOL_time_ms": {
+            "XPU-A": 18.68,
+            "H20": 29.36
+          },
+          "prod_us": {
+            "XPU-A": 767.6
+          }
+        },
+        "12": {
+          "description": "(vLLM TP1), chunk state update, tokens=24576 heads=2/4 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 24576,
+            "num_v_heads": 4,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 2,
+            "batch_size": 1
+          },
+          "W_flops": 6518046720,
+          "Q_bytes": 139329540,
+          "ai": 46.8,
+          "SOL_time_ms": {
+            "XPU-A": 28.02,
+            "H20": 44.04
+          },
+          "prod_us": {
+            "XPU-A": 1203.7
+          }
+        },
+        "13": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=3/6 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 6,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 3,
+            "batch_size": 1
+          },
+          "W_flops": 814755840,
+          "Q_bytes": 18137092,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 3.5,
+            "H20": 5.51
+          },
+          "prod_us": {
+            "XPU-A": 94.2
+          }
+        },
+        "14": {
+          "description": "(vLLM TP4), chunk state update, tokens=512 heads=4/8 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 512,
+            "num_v_heads": 8,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 4,
+            "batch_size": 1
+          },
+          "W_flops": 271585280,
+          "Q_bytes": 6832132,
+          "ai": 39.8,
+          "SOL_time_ms": {
+            "XPU-A": 1.29,
+            "H20": 1.84
+          },
+          "prod_us": {
+            "XPU-A": 32.2
+          }
+        },
+        "15": {
+          "description": "(vLLM TP4), chunk state update, tokens=1024 heads=4/8 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 1024,
+            "num_v_heads": 8,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 4,
+            "batch_size": 1
+          },
+          "W_flops": 543170560,
+          "Q_bytes": 12615684,
+          "ai": 43.1,
+          "SOL_time_ms": {
+            "XPU-A": 2.38,
+            "H20": 3.67
+          },
+          "prod_us": {
+            "XPU-A": 54.1
+          }
+        },
+        "16": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=4/8 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 8,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 4,
+            "batch_size": 1
+          },
+          "W_flops": 1086341120,
+          "Q_bytes": 24182788,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 4.67,
+            "H20": 7.34
+          },
+          "prod_us": {
+            "XPU-A": 97.1
+          }
+        },
+        "17": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=5/10 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 10,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 5,
+            "batch_size": 1
+          },
+          "W_flops": 1357926400,
+          "Q_bytes": 30228484,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 5.84,
+            "H20": 9.18
+          },
+          "prod_us": {
+            "XPU-A": 95.7
+          }
+        },
+        "18": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=6/12 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 12,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 6,
+            "batch_size": 1
+          },
+          "W_flops": 1629511680,
+          "Q_bytes": 36274180,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 7.0,
+            "H20": 11.01
+          },
+          "prod_us": {
+            "XPU-A": 184.3
+          }
+        },
+        "19": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=7/14 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 14,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 7,
+            "batch_size": 1
+          },
+          "W_flops": 1901096960,
+          "Q_bytes": 42319876,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 8.17,
+            "H20": 12.85
+          },
+          "prod_us": {
+            "XPU-A": 181.9
+          }
+        },
+        "20": {
+          "description": "(SGLang TP8), chunk state update, tokens=1024 heads=8/16 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 1024,
+            "num_v_heads": 16,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 8,
+            "batch_size": 1
+          },
+          "W_flops": 1086341120,
+          "Q_bytes": 25231364,
+          "ai": 43.1,
+          "SOL_time_ms": {
+            "XPU-A": 4.76,
+            "H20": 7.34
+          },
+          "prod_us": {
+            "XPU-A": 101.6
+          }
+        },
+        "21": {
+          "description": "(SGLang TP8), chunk state update, tokens=2048 heads=8/16 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 16,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 8,
+            "batch_size": 1
+          },
+          "W_flops": 2172682240,
+          "Q_bytes": 48365572,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 9.34,
+            "H20": 14.68
+          },
+          "prod_us": {
+            "XPU-A": 188.4
+          }
+        },
+        "22": {
+          "description": "(vLLM TP1), chunk state update, tokens=2048 heads=9/18 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 18,
+            "state_count": 474,
+            "value_dim": 128,
+            "key_dim": 128,
+            "num_k_heads": 9,
+            "batch_size": 1
+          },
+          "W_flops": 2444267520,
+          "Q_bytes": 54411268,
+          "ai": 44.9,
+          "SOL_time_ms": {
+            "XPU-A": 10.51,
+            "H20": 16.52
+          },
+          "prod_us": {
+            "XPU-A": 182.6
+          }
+        },
+        "23": {
+          "description": "(SGLang/vLLM), chunk state update, tokens=4195 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "batch_size": 1,
+            "token_count": 4195,
+            "num_k_heads": 16,
+            "num_v_heads": 32,
+            "key_dim": 128,
+            "value_dim": 128,
+            "state_count": 1116
+          },
+          "W_flops": 8901258336,
+          "Q_bytes": 194216324,
+          "ai": 45.8,
+          "SOL_time_ms": {
+            "XPU-A": 38.26,
+            "H20": 60.14
+          },
+          "prod_us": {
+            "XPU-A": 899.5
+          }
+        },
+        "24": {
+          "description": "(SGLang/vLLM), chunk state update, tokens=11027 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "batch_size": 1,
+            "token_count": 11027,
+            "num_k_heads": 16,
+            "num_v_heads": 32,
+            "key_dim": 128,
+            "value_dim": 128,
+            "state_count": 1116
+          },
+          "W_flops": 23397384800,
+          "Q_bytes": 503175556,
+          "ai": 46.5,
+          "SOL_time_ms": {
+            "XPU-A": 100.57,
+            "H20": 158.09
+          },
+          "prod_us": {
+            "XPU-A": 2352.4
+          }
+        }
+      }
+    },
+    {
+      "name": "fused_add_rms_norm",
+      "id": "atrex_008",
+      "dtype": "bf16",
+      "framework": "vllm",
+      "symbol": "fused_add_rms_norm",
+      "module": "vllm.csrc.layernorm_kernels",
+      "phase": "prefill/decode",
+      "shapes": 19,
+      "importance": 0.011487,
+      "roofline": {
+        "median_ai": 0.5,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 126754992,
+          "Q_bytes": 253463040,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 47.82,
+            "H20": 63.37
+          },
+          "description": "(rtp-llm), fused add RMSNorm, tokens=24752 hidden=1280"
+        },
+        "1": {
+          "W_flops": 1032318,
+          "Q_bytes": 2068480,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 0.39,
+            "H20": 0.52
+          },
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=126 hidden=2048"
+        },
+        "2": {
+          "W_flops": 2105601,
+          "Q_bytes": 4214784,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 0.8,
+            "H20": 1.05
+          },
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=257 hidden=2048"
+        },
+        "3": {
+          "W_flops": 4162044,
+          "Q_bytes": 8327168,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 1.57,
+            "H20": 2.08
+          },
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=508 hidden=2048"
+        },
+        "4": {
+          "W_flops": 8389632,
+          "Q_bytes": 16781312,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 3.17,
+            "H20": 4.2
+          },
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=1024 hidden=2048"
+        },
+        "5": {
+          "W_flops": 16648176,
+          "Q_bytes": 33296384,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 6.28,
+            "H20": 8.32
+          },
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=2032 hidden=2048"
+        },
+        "6": {
+          "W_flops": 33558528,
+          "Q_bytes": 67112960,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 12.66,
+            "H20": 16.78
+          },
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=4096 hidden=2048"
+        },
+        "7": {
+          "W_flops": 2887821,
+          "Q_bytes": 5785600,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 1.09,
+            "H20": 1.45
+          },
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=141 hidden=5120"
+        },
+        "8": {
+          "W_flops": 5816604,
+          "Q_bytes": 11642880,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 2.2,
+            "H20": 2.91
+          },
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=284 hidden=5120"
+        },
+        "9": {
+          "W_flops": 11428398,
+          "Q_bytes": 22865920,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 4.31,
+            "H20": 5.72
+          },
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=558 hidden=5120"
+        },
+        "10": {
+          "W_flops": 20972544,
+          "Q_bytes": 41953280,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 7.92,
+            "H20": 10.49
+          },
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=1024 hidden=5120"
+        },
+        "11": {
+          "W_flops": 35227320,
+          "Q_bytes": 70461440,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 13.29,
+            "H20": 17.62
+          },
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=1720 hidden=5120"
+        },
+        "12": {
+          "W_flops": 86122605,
+          "Q_bytes": 172247040,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 32.5,
+            "H20": 43.06
+          },
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=4205 hidden=5120"
+        },
+        "13": {
+          "W_flops": 1519669,
+          "Q_bytes": 3053568,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 0.58,
+            "H20": 0.76
+          },
+          "description": "(SGLang TP8), fused add RMSNorm, tokens=53 hidden=7168"
+        },
+        "14": {
+          "W_flops": 4042893,
+          "Q_bytes": 8099840,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 1.53,
+            "H20": 2.02
+          },
+          "description": "(SGLang TP8), fused add RMSNorm, tokens=141 hidden=7168"
+        },
+        "15": {
+          "W_flops": 18121336,
+          "Q_bytes": 36255744,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 6.84,
+            "H20": 9.06
+          },
+          "description": "(SGLang TP8), fused add RMSNorm, tokens=632 hidden=7168"
+        },
+        "16": {
+          "W_flops": 26293141,
+          "Q_bytes": 52598784,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 9.92,
+            "H20": 13.15
+          },
+          "description": "(SGLang TP8), fused add RMSNorm, tokens=917 hidden=7168"
+        },
+        "17": {
+          "W_flops": 48400024,
+          "Q_bytes": 96811008,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 18.27,
+            "H20": 24.2
+          },
+          "description": "(SGLang/vLLM), fused add RMSNorm, tokens=1688 hidden=7168"
+        },
+        "18": {
+          "W_flops": 109072092,
+          "Q_bytes": 218150912,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 41.16,
+            "H20": 54.54
+          },
+          "description": "(SGLang/vLLM), fused add RMSNorm, tokens=3804 hidden=7168"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 19,
+          "median_us": 16.8,
+          "min_us": 7.8,
+          "max_us": 105.2,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 105.2,
+          "1": 7.8,
+          "2": 8.4,
+          "3": 8.4,
+          "4": 11.6,
+          "5": 16.8,
+          "6": 27.9,
+          "7": 8.1,
+          "8": 10.1,
+          "9": 13.8,
+          "10": 20.7,
+          "11": 31.2,
+          "12": 66.1,
+          "13": 7.9,
+          "14": 8.8,
+          "15": 18.5,
+          "16": 24.7,
+          "17": 40.0,
+          "18": 81.2
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self, eps: float=1e-06) -> None:\n        super().__init__()\n        self.eps = float(eps)\n\n    def forward(self, x: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor) -> dict[str, torch.Tensor]:\n        residual_out = (x + residual).to(residual.dtype)\n        residual_float = residual_out.float()\n        variance = residual_float.square().mean(dim=-1, keepdim=True)\n        normed = residual_float * torch.rsqrt(variance + self.eps) * weight.float()\n        return {'out': normed.to(x.dtype), 'residual': residual_out}\n",
+      "input_code": "import torch\n\ndef _make_inputs(token_count: int, hidden_size: int) -> dict[str, torch.Tensor]:\n    x = torch.randn(token_count, hidden_size, dtype=torch.bfloat16, device='cuda') * 0.02\n    residual = torch.randn_like(x)\n    weight = torch.randn(hidden_size, dtype=torch.bfloat16, device='cuda') * 0.02 + 1.0\n    return {'x': x, 'residual': residual, 'weight': weight}\n",
+      "shape_details": {
+        "0": {
+          "description": "(rtp-llm), fused add RMSNorm, tokens=24752 hidden=1280",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 24752,
+            "hidden_size": 1280
+          },
+          "W_flops": 126754992,
+          "Q_bytes": 253463040,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 47.82,
+            "H20": 63.37
+          },
+          "prod_us": {
+            "XPU-A": 105.2
+          }
+        },
+        "1": {
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=126 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 126,
+            "hidden_size": 2048
+          },
+          "W_flops": 1032318,
+          "Q_bytes": 2068480,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 0.39,
+            "H20": 0.52
+          },
+          "prod_us": {
+            "XPU-A": 7.8
+          }
+        },
+        "2": {
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=257 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 257,
+            "hidden_size": 2048
+          },
+          "W_flops": 2105601,
+          "Q_bytes": 4214784,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 0.8,
+            "H20": 1.05
+          },
+          "prod_us": {
+            "XPU-A": 8.4
+          }
+        },
+        "3": {
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=508 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 508,
+            "hidden_size": 2048
+          },
+          "W_flops": 4162044,
+          "Q_bytes": 8327168,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 1.57,
+            "H20": 2.08
+          },
+          "prod_us": {
+            "XPU-A": 8.4
+          }
+        },
+        "4": {
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=1024 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 1024,
+            "hidden_size": 2048
+          },
+          "W_flops": 8389632,
+          "Q_bytes": 16781312,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 3.17,
+            "H20": 4.2
+          },
+          "prod_us": {
+            "XPU-A": 11.6
+          }
+        },
+        "5": {
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=2032 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 2032,
+            "hidden_size": 2048
+          },
+          "W_flops": 16648176,
+          "Q_bytes": 33296384,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 6.28,
+            "H20": 8.32
+          },
+          "prod_us": {
+            "XPU-A": 16.8
+          }
+        },
+        "6": {
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=4096 hidden=2048",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 4096,
+            "hidden_size": 2048
+          },
+          "W_flops": 33558528,
+          "Q_bytes": 67112960,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 12.66,
+            "H20": 16.78
+          },
+          "prod_us": {
+            "XPU-A": 27.9
+          }
+        },
+        "7": {
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=141 hidden=5120",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 141,
+            "hidden_size": 5120
+          },
+          "W_flops": 2887821,
+          "Q_bytes": 5785600,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 1.09,
+            "H20": 1.45
+          },
+          "prod_us": {
+            "XPU-A": 8.1
+          }
+        },
+        "8": {
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=284 hidden=5120",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 284,
+            "hidden_size": 5120
+          },
+          "W_flops": 5816604,
+          "Q_bytes": 11642880,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 2.2,
+            "H20": 2.91
+          },
+          "prod_us": {
+            "XPU-A": 10.1
+          }
+        },
+        "9": {
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=558 hidden=5120",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 558,
+            "hidden_size": 5120
+          },
+          "W_flops": 11428398,
+          "Q_bytes": 22865920,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 4.31,
+            "H20": 5.72
+          },
+          "prod_us": {
+            "XPU-A": 13.8
+          }
+        },
+        "10": {
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=1024 hidden=5120",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 1024,
+            "hidden_size": 5120
+          },
+          "W_flops": 20972544,
+          "Q_bytes": 41953280,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 7.92,
+            "H20": 10.49
+          },
+          "prod_us": {
+            "XPU-A": 20.7
+          }
+        },
+        "11": {
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=1720 hidden=5120",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 1720,
+            "hidden_size": 5120
+          },
+          "W_flops": 35227320,
+          "Q_bytes": 70461440,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 13.29,
+            "H20": 17.62
+          },
+          "prod_us": {
+            "XPU-A": 31.2
+          }
+        },
+        "12": {
+          "description": "(vLLM TP1), fused add RMSNorm, tokens=4205 hidden=5120",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 4205,
+            "hidden_size": 5120
+          },
+          "W_flops": 86122605,
+          "Q_bytes": 172247040,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 32.5,
+            "H20": 43.06
+          },
+          "prod_us": {
+            "XPU-A": 66.1
+          }
+        },
+        "13": {
+          "description": "(SGLang TP8), fused add RMSNorm, tokens=53 hidden=7168",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 53,
+            "hidden_size": 7168
+          },
+          "W_flops": 1519669,
+          "Q_bytes": 3053568,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 0.58,
+            "H20": 0.76
+          },
+          "prod_us": {
+            "XPU-A": 7.9
+          }
+        },
+        "14": {
+          "description": "(SGLang TP8), fused add RMSNorm, tokens=141 hidden=7168",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 141,
+            "hidden_size": 7168
+          },
+          "W_flops": 4042893,
+          "Q_bytes": 8099840,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 1.53,
+            "H20": 2.02
+          },
+          "prod_us": {
+            "XPU-A": 8.8
+          }
+        },
+        "15": {
+          "description": "(SGLang TP8), fused add RMSNorm, tokens=632 hidden=7168",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 632,
+            "hidden_size": 7168
+          },
+          "W_flops": 18121336,
+          "Q_bytes": 36255744,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 6.84,
+            "H20": 9.06
+          },
+          "prod_us": {
+            "XPU-A": 18.5
+          }
+        },
+        "16": {
+          "description": "(SGLang TP8), fused add RMSNorm, tokens=917 hidden=7168",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 917,
+            "hidden_size": 7168
+          },
+          "W_flops": 26293141,
+          "Q_bytes": 52598784,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 9.92,
+            "H20": 13.15
+          },
+          "prod_us": {
+            "XPU-A": 24.7
+          }
+        },
+        "17": {
+          "description": "(SGLang/vLLM), fused add RMSNorm, tokens=1688 hidden=7168",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 1688,
+            "hidden_size": 7168
+          },
+          "W_flops": 48400024,
+          "Q_bytes": 96811008,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 18.27,
+            "H20": 24.2
+          },
+          "prod_us": {
+            "XPU-A": 40.0
+          }
+        },
+        "18": {
+          "description": "(SGLang/vLLM), fused add RMSNorm, tokens=3804 hidden=7168",
+          "init_kwargs": {
+            "eps": 1e-06
+          },
+          "input_kwargs": {
+            "token_count": 3804,
+            "hidden_size": 7168
+          },
+          "W_flops": 109072092,
+          "Q_bytes": 218150912,
+          "ai": 0.5,
+          "SOL_time_ms": {
+            "XPU-A": 41.16,
+            "H20": 54.54
+          },
+          "prod_us": {
+            "XPU-A": 81.2
+          }
+        }
+      }
+    },
+    {
+      "name": "moe_align_block_size",
+      "id": "atrex_019",
+      "dtype": "int32",
+      "framework": "vllm",
+      "symbol": "moe_align_block_size",
+      "module": "vllm.model_executor.layers.fused_moe.moe_align_block_size",
+      "phase": "prefill/decode",
+      "shapes": 6,
+      "importance": 0.011082,
+      "roofline": {
+        "median_ai": 0.0,
+        "regime": "indexing/structural",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 0,
+          "Q_bytes": 4164,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(vLLM TP1), MoE routing align_block_size, tokens=1 top_k=8 block_size=128"
+        },
+        "2": {
+          "W_flops": 0,
+          "Q_bytes": 82692,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.02,
+            "H20": 0.02
+          },
+          "description": "(vLLM TP4), MoE routing align_block_size, tokens=520 top_k=8 block_size=128"
+        },
+        "3": {
+          "W_flops": 0,
+          "Q_bytes": 98660,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.02,
+            "H20": 0.02
+          },
+          "description": "(vLLM TP4), MoE routing align_block_size, tokens=1019 top_k=8 block_size=128"
+        },
+        "4": {
+          "W_flops": 0,
+          "Q_bytes": 161388,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.03,
+            "H20": 0.04
+          },
+          "description": "(vLLM TP4), MoE routing align_block_size, tokens=2044 top_k=8 block_size=128"
+        },
+        "5": {
+          "W_flops": 0,
+          "Q_bytes": 276628,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.05,
+            "H20": 0.07
+          },
+          "description": "(vLLM TP4), MoE routing align_block_size, tokens=3936 top_k=8 block_size=128"
+        },
+        "6": {
+          "W_flops": 0,
+          "Q_bytes": 557816,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.11,
+            "H20": 0.14
+          },
+          "description": "(vLLM TP4), MoE routing align_block_size, tokens=8192 top_k=8 block_size=128"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 6,
+          "median_us": 122.0,
+          "min_us": 23.0,
+          "max_us": 400.4,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 23.0,
+          "2": 42.0,
+          "3": 67.2,
+          "4": 122.0,
+          "5": 187.9,
+          "6": 400.4
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self, block_size: int, num_experts: int) -> None:\n        super().__init__()\n        self.block_size = block_size\n        self.num_experts = num_experts\n\n    def forward(self, topk_ids: torch.Tensor) -> dict[str, torch.Tensor]:\n        flat_ids = topk_ids.flatten()\n        total_tokens = flat_ids.numel()\n        sorted_chunks = []\n        expert_blocks = []\n        for expert in range(self.num_experts):\n            token_ids = torch.nonzero(flat_ids == expert, as_tuple=False).flatten().to(torch.int32)\n            if token_ids.numel() == 0:\n                continue\n            pad = -token_ids.numel() % self.block_size\n            if pad:\n                padding = torch.full((pad,), total_tokens, dtype=torch.int32, device=topk_ids.device)\n                token_ids = torch.cat([token_ids, padding])\n            sorted_chunks.append(token_ids)\n            expert_blocks.extend([expert] * (token_ids.numel() // self.block_size))\n        if sorted_chunks:\n            sorted_token_ids = torch.cat(sorted_chunks)\n        else:\n            sorted_token_ids = torch.empty((0,), dtype=torch.int32, device=topk_ids.device)\n        expert_ids = torch.tensor(expert_blocks, dtype=torch.int32, device=topk_ids.device)\n        num_tokens_post_pad = torch.tensor([sorted_token_ids.numel()], dtype=torch.int32, device=topk_ids.device)\n        return {'sorted_token_ids': sorted_token_ids, 'expert_ids': expert_ids, 'num_tokens_post_pad': num_tokens_post_pad}\n",
+      "input_code": "import torch\n\ndef _make_inputs(token_count: int, top_k: int, num_experts: int) -> dict[str, torch.Tensor]:\n    topk_ids = torch.randint(0, num_experts, (token_count, top_k), dtype=torch.int32, device='cuda')\n    return {'topk_ids': topk_ids}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM TP1), MoE routing align_block_size, tokens=1 top_k=8 block_size=128",
+          "init_kwargs": {
+            "block_size": 128,
+            "num_experts": 128
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 0,
+          "Q_bytes": 4164,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 23.0
+          }
+        },
+        "2": {
+          "description": "(vLLM TP4), MoE routing align_block_size, tokens=520 top_k=8 block_size=128",
+          "init_kwargs": {
+            "block_size": 128,
+            "num_experts": 128
+          },
+          "input_kwargs": {
+            "token_count": 520,
+            "top_k": 8,
+            "num_experts": 128
+          },
+          "W_flops": 0,
+          "Q_bytes": 82692,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.02,
+            "H20": 0.02
+          },
+          "prod_us": {
+            "XPU-A": 42.0
+          }
+        },
+        "3": {
+          "description": "(vLLM TP4), MoE routing align_block_size, tokens=1019 top_k=8 block_size=128",
+          "init_kwargs": {
+            "block_size": 128,
+            "num_experts": 128
+          },
+          "input_kwargs": {
+            "token_count": 1019,
+            "top_k": 8,
+            "num_experts": 128
+          },
+          "W_flops": 0,
+          "Q_bytes": 98660,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.02,
+            "H20": 0.02
+          },
+          "prod_us": {
+            "XPU-A": 67.2
+          }
+        },
+        "4": {
+          "description": "(vLLM TP4), MoE routing align_block_size, tokens=2044 top_k=8 block_size=128",
+          "init_kwargs": {
+            "block_size": 128,
+            "num_experts": 128
+          },
+          "input_kwargs": {
+            "token_count": 2044,
+            "top_k": 8,
+            "num_experts": 128
+          },
+          "W_flops": 0,
+          "Q_bytes": 161388,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.03,
+            "H20": 0.04
+          },
+          "prod_us": {
+            "XPU-A": 122.0
+          }
+        },
+        "5": {
+          "description": "(vLLM TP4), MoE routing align_block_size, tokens=3936 top_k=8 block_size=128",
+          "init_kwargs": {
+            "block_size": 128,
+            "num_experts": 128
+          },
+          "input_kwargs": {
+            "token_count": 3936,
+            "top_k": 8,
+            "num_experts": 128
+          },
+          "W_flops": 0,
+          "Q_bytes": 276628,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.05,
+            "H20": 0.07
+          },
+          "prod_us": {
+            "XPU-A": 187.9
+          }
+        },
+        "6": {
+          "description": "(vLLM TP4), MoE routing align_block_size, tokens=8192 top_k=8 block_size=128",
+          "init_kwargs": {
+            "block_size": 128,
+            "num_experts": 128
+          },
+          "input_kwargs": {
+            "token_count": 8192,
+            "top_k": 8,
+            "num_experts": 128
+          },
+          "W_flops": 0,
+          "Q_bytes": 557816,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.11,
+            "H20": 0.14
+          },
+          "prod_us": {
+            "XPU-A": 400.4
+          }
+        }
+      }
+    },
+    {
+      "name": "mrope",
+      "id": "atrex_023",
+      "dtype": "bf16",
+      "framework": "vllm",
+      "symbol": "triton_mrope",
+      "module": "vllm.model_executor.layers.rotary_embedding.mrope",
+      "phase": "prefill/decode",
+      "shapes": 5,
+      "importance": 0.010032,
+      "roofline": {
+        "median_ai": 0.6,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 23448576,
+          "Q_bytes": 36782080,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 6.94,
+            "H20": 9.2
+          },
+          "description": "(vLLM TP2), tokens=3592 heads=16/1 head_dim=128"
+        },
+        "1": {
+          "W_flops": 54658944,
+          "Q_bytes": 85739520,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 16.18,
+            "H20": 21.43
+          },
+          "description": "(vLLM TP2), tokens=8373 heads=16/1 head_dim=128"
+        },
+        "2": {
+          "W_flops": 107907840,
+          "Q_bytes": 169267200,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 31.94,
+            "H20": 42.32
+          },
+          "description": "(vLLM TP2), tokens=16530 heads=16/1 head_dim=128"
+        },
+        "3": {
+          "W_flops": 6435840,
+          "Q_bytes": 9868288,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 1.86,
+            "H20": 2.47
+          },
+          "description": "(sglang), tokens=838 heads=16/4 head_dim=128"
+        },
+        "4": {
+          "W_flops": 12848640,
+          "Q_bytes": 19701248,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.72,
+            "H20": 4.93
+          },
+          "description": "(sglang), tokens=1673 heads=16/4 head_dim=128"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 5,
+          "median_us": 46.0,
+          "min_us": 17.7,
+          "max_us": 139.0,
+          "framework": "sglang"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 46.0,
+          "1": 78.3,
+          "2": 139.0,
+          "3": 17.7,
+          "4": 28.4
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self, head_size: int, rotary_dim: int, mrope_section: list[int], mrope_interleaved: bool=False, is_neox_style: bool=True) -> None:\n        super().__init__()\n        self.head_size = int(head_size)\n        self.rotary_dim = int(rotary_dim)\n        self.mrope_section = [int(x) for x in mrope_section]\n        self.mrope_interleaved = bool(mrope_interleaved)\n        self.is_neox_style = bool(is_neox_style)\n\n    def forward(self, q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> dict[str, torch.Tensor]:\n        return {'q': self._rotate(q, cos, sin), 'k': self._rotate(k, cos, sin)}\n\n    def _rotate(self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:\n        tokens = x.shape[0]\n        heads = x.shape[1] // self.head_size\n        x_view = x.reshape(tokens, heads, self.head_size).clone()\n        half = self.rotary_dim // 2\n        axis = self._axis_map(half, x.device)\n        pos = torch.arange(tokens, device=x.device)[:, None]\n        freq = torch.arange(half, device=x.device)[None, :]\n        cos_row = cos[axis[None, :], pos, freq]\n        sin_row = sin[axis[None, :], pos, freq]\n        if self.is_neox_style:\n            x1 = x_view[:, :, :half].float()\n            x2 = x_view[:, :, half:self.rotary_dim].float()\n            c = cos_row[:, None, :].float()\n            s = sin_row[:, None, :].float()\n            x_view[:, :, :half] = (x1 * c - x2 * s).to(x.dtype)\n            x_view[:, :, half:self.rotary_dim] = (x2 * c + x1 * s).to(x.dtype)\n        else:\n            even = x_view[:, :, :self.rotary_dim:2].float()\n            odd = x_view[:, :, 1:self.rotary_dim:2].float()\n            c = cos_row[:, None, :].float()\n            s = sin_row[:, None, :].float()\n            x_view[:, :, :self.rotary_dim:2] = (even * c - odd * s).to(x.dtype)\n            x_view[:, :, 1:self.rotary_dim:2] = (odd * c + even * s).to(x.dtype)\n        return x_view.reshape_as(x)\n\n    def _axis_map(self, half: int, device: torch.device) -> torch.Tensor:\n        offsets = torch.arange(half, device=device)\n        if self.mrope_interleaved:\n            h = (offsets % 3 == 1) & (offsets <= 3 * self.mrope_section[1])\n            w = (offsets % 3 == 2) & (offsets <= 3 * self.mrope_section[2])\n            return torch.where(h, 1, torch.where(w, 2, 0)).long()\n        t_end = self.mrope_section[0]\n        h_end = t_end + self.mrope_section[1]\n        return torch.where(offsets < t_end, 0, torch.where(offsets < h_end, 1, 2)).long()\n",
+      "input_code": "import torch\n\ndef _make_inputs(token_count: int, num_query_heads: int, num_kv_heads: int, head_size: int, rotary_dim: int) -> dict[str, torch.Tensor]:\n    q = torch.randn(token_count, num_query_heads * head_size, dtype=torch.bfloat16, device='cuda') * 0.02\n    k = torch.randn(token_count, num_kv_heads * head_size, dtype=torch.bfloat16, device='cuda') * 0.02\n    half = rotary_dim // 2\n    angles = torch.randn(3, token_count, half, dtype=torch.float32, device='cuda') * 0.1\n    return {'q': q, 'k': k, 'cos': torch.cos(angles), 'sin': torch.sin(angles)}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM TP2), tokens=3592 heads=16/1 head_dim=128",
+          "init_kwargs": {
+            "head_size": 128,
+            "rotary_dim": 128,
+            "mrope_section": [
+              16,
+              24,
+              24
+            ],
+            "mrope_interleaved": false,
+            "is_neox_style": true
+          },
+          "input_kwargs": {
+            "token_count": 3592,
+            "num_query_heads": 16,
+            "num_kv_heads": 1,
+            "head_size": 128,
+            "rotary_dim": 128
+          },
+          "W_flops": 23448576,
+          "Q_bytes": 36782080,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 6.94,
+            "H20": 9.2
+          },
+          "prod_us": {
+            "XPU-A": 46.0
+          }
+        },
+        "1": {
+          "description": "(vLLM TP2), tokens=8373 heads=16/1 head_dim=128",
+          "init_kwargs": {
+            "head_size": 128,
+            "rotary_dim": 128,
+            "mrope_section": [
+              16,
+              24,
+              24
+            ],
+            "mrope_interleaved": false,
+            "is_neox_style": true
+          },
+          "input_kwargs": {
+            "token_count": 8373,
+            "num_query_heads": 16,
+            "num_kv_heads": 1,
+            "head_size": 128,
+            "rotary_dim": 128
+          },
+          "W_flops": 54658944,
+          "Q_bytes": 85739520,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 16.18,
+            "H20": 21.43
+          },
+          "prod_us": {
+            "XPU-A": 78.3
+          }
+        },
+        "2": {
+          "description": "(vLLM TP2), tokens=16530 heads=16/1 head_dim=128",
+          "init_kwargs": {
+            "head_size": 128,
+            "rotary_dim": 128,
+            "mrope_section": [
+              16,
+              24,
+              24
+            ],
+            "mrope_interleaved": false,
+            "is_neox_style": true
+          },
+          "input_kwargs": {
+            "token_count": 16530,
+            "num_query_heads": 16,
+            "num_kv_heads": 1,
+            "head_size": 128,
+            "rotary_dim": 128
+          },
+          "W_flops": 107907840,
+          "Q_bytes": 169267200,
+          "ai": 0.6,
+          "SOL_time_ms": {
+            "XPU-A": 31.94,
+            "H20": 42.32
+          },
+          "prod_us": {
+            "XPU-A": 139.0
+          }
+        },
+        "3": {
+          "description": "(sglang), tokens=838 heads=16/4 head_dim=128",
+          "init_kwargs": {
+            "head_size": 128,
+            "rotary_dim": 128,
+            "mrope_section": [
+              16,
+              24,
+              24
+            ],
+            "mrope_interleaved": false,
+            "is_neox_style": true
+          },
+          "input_kwargs": {
+            "token_count": 838,
+            "num_query_heads": 16,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "rotary_dim": 128
+          },
+          "W_flops": 6435840,
+          "Q_bytes": 9868288,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 1.86,
+            "H20": 2.47
+          },
+          "prod_us": {
+            "XPU-A": 17.7
+          }
+        },
+        "4": {
+          "description": "(sglang), tokens=1673 heads=16/4 head_dim=128",
+          "init_kwargs": {
+            "head_size": 128,
+            "rotary_dim": 128,
+            "mrope_section": [
+              16,
+              24,
+              24
+            ],
+            "mrope_interleaved": false,
+            "is_neox_style": true
+          },
+          "input_kwargs": {
+            "token_count": 1673,
+            "num_query_heads": 16,
+            "num_kv_heads": 4,
+            "head_size": 128,
+            "rotary_dim": 128
+          },
+          "W_flops": 12848640,
+          "Q_bytes": 19701248,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.72,
+            "H20": 4.93
+          },
+          "prod_us": {
+            "XPU-A": 28.4
+          }
+        }
+      }
+    },
+    {
+      "name": "chunk_delta_rule_output",
+      "id": "atrex_004",
+      "dtype": "bf16",
+      "framework": "sglang",
+      "symbol": "chunk_fwd_o",
+      "module": "sglang.srt.layers.attention.fla.chunk_o",
+      "phase": "prefill",
+      "shapes": 16,
+      "importance": 0.008234,
+      "roofline": {
+        "median_ai": 51.4,
+        "regime": "compute-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 135266304,
+          "Q_bytes": 2629632,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 0.58,
+            "H20": 0.91
+          },
+          "description": "(vLLM TP1), chunk output, tokens=64 heads=16/32 dim=128/128"
+        },
+        "1": {
+          "W_flops": 270532608,
+          "Q_bytes": 5259264,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 1.16,
+            "H20": 1.83
+          },
+          "description": "(vLLM TP1), chunk output, tokens=128 heads=16/32 dim=128/128"
+        },
+        "2": {
+          "W_flops": 541065216,
+          "Q_bytes": 10518528,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 2.33,
+            "H20": 3.66
+          },
+          "description": "(vLLM TP1), chunk output, tokens=256 heads=16/32 dim=128/128"
+        },
+        "3": {
+          "W_flops": 1082130432,
+          "Q_bytes": 21037056,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 4.65,
+            "H20": 7.31
+          },
+          "description": "(vLLM TP1), chunk output, tokens=512 heads=16/32 dim=128/128"
+        },
+        "4": {
+          "W_flops": 2164260864,
+          "Q_bytes": 42074112,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 9.3,
+            "H20": 14.62
+          },
+          "description": "(vLLM TP1), chunk output, tokens=1024 heads=16/32 dim=128/128"
+        },
+        "5": {
+          "W_flops": 4328521728,
+          "Q_bytes": 84148224,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 18.61,
+            "H20": 29.25
+          },
+          "description": "(vLLM TP1), chunk output, tokens=2048 heads=16/32 dim=128/128"
+        },
+        "6": {
+          "W_flops": 8657043456,
+          "Q_bytes": 168296448,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 37.21,
+            "H20": 58.49
+          },
+          "description": "(vLLM TP1), chunk output, tokens=4096 heads=16/32 dim=128/128"
+        },
+        "7": {
+          "W_flops": 17314086912,
+          "Q_bytes": 336592896,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 74.42,
+            "H20": 116.99
+          },
+          "description": "(vLLM TP1), chunk output, tokens=8192 heads=16/32 dim=128/128"
+        },
+        "8": {
+          "W_flops": 743964672,
+          "Q_bytes": 14462976,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 3.2,
+            "H20": 5.03
+          },
+          "description": "(SGLang TP8), chunk output, tokens=704 heads=8/16 dim=128/128"
+        },
+        "9": {
+          "W_flops": 1082130432,
+          "Q_bytes": 21037056,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 4.65,
+            "H20": 7.31
+          },
+          "description": "(SGLang TP8), chunk output, tokens=1024 heads=8/16 dim=128/128"
+        },
+        "10": {
+          "W_flops": 2231894016,
+          "Q_bytes": 43388928,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 9.59,
+            "H20": 15.08
+          },
+          "description": "(SGLang TP8), chunk output, tokens=2112 heads=8/16 dim=128/128"
+        },
+        "11": {
+          "W_flops": 4328521728,
+          "Q_bytes": 84148224,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 18.61,
+            "H20": 29.25
+          },
+          "description": "(SGLang TP8), chunk output, tokens=4096 heads=8/16 dim=128/128"
+        },
+        "12": {
+          "W_flops": 8724676608,
+          "Q_bytes": 169611264,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 37.5,
+            "H20": 58.95
+          },
+          "description": "(SGLang TP8), chunk output, tokens=8256 heads=8/16 dim=128/128"
+        },
+        "13": {
+          "W_flops": 8927576064,
+          "Q_bytes": 172839296,
+          "ai": 51.7,
+          "SOL_time_ms": {
+            "XPU-A": 38.37,
+            "H20": 60.32
+          },
+          "description": "(SGLang/vLLM), chunk output, tokens=4195 heads=16/32 dim=128/128"
+        },
+        "14": {
+          "W_flops": 23401070592,
+          "Q_bytes": 453814656,
+          "ai": 51.6,
+          "SOL_time_ms": {
+            "XPU-A": 100.58,
+            "H20": 158.12
+          },
+          "description": "(SGLang/vLLM), chunk output, tokens=11027 heads=16/32 dim=128/128"
+        },
+        "15": {
+          "W_flops": 31381782528,
+          "Q_bytes": 609061760,
+          "ai": 51.5,
+          "SOL_time_ms": {
+            "XPU-A": 134.89,
+            "H20": 212.04
+          },
+          "description": "(SGLang/vLLM), chunk output, tokens=14807 heads=16/32 dim=128/128"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 16,
+          "median_us": 190.5,
+          "min_us": 20.2,
+          "max_us": 1291.6,
+          "framework": "sglang"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 20.2,
+          "1": 23.9,
+          "2": 37.1,
+          "3": 57.9,
+          "4": 97.2,
+          "5": 190.5,
+          "6": 372.9,
+          "7": 725.5,
+          "8": 46.7,
+          "9": 59.9,
+          "10": 103.1,
+          "11": 195.8,
+          "12": 385.0,
+          "13": 403.6,
+          "14": 1055.1,
+          "15": 1291.6
+        }
+      },
+      "reference_code": "import math\nimport torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self, chunk_size: int=64, scale: float | None=None) -> None:\n        super().__init__()\n        self.chunk_size = int(chunk_size)\n        self.scale = scale\n\n    def forward(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, h: torch.Tensor, g: torch.Tensor) -> torch.Tensor:\n        (batch, tokens, num_q_heads, key_dim) = q.shape\n        (num_heads, value_dim) = (v.shape[2], v.shape[3])\n        heads_per_q = max(num_heads // num_q_heads, 1)\n        cs = self.chunk_size\n        scale = self.scale if self.scale is not None else key_dim ** (-0.5)\n        num_chunks = math.ceil(tokens / cs)\n        tokens_padded = num_chunks * cs\n        pad = tokens_padded - tokens\n        head_to_qhead = torch.tensor([min(hd // heads_per_q, num_q_heads - 1) for hd in range(num_heads)], dtype=torch.long, device=q.device)\n        q_h = q.index_select(2, head_to_qhead)\n        k_h = k.index_select(2, head_to_qhead)\n        if pad > 0:\n            q_h = F.pad(q_h, (0, 0, 0, 0, 0, pad))\n            k_h = F.pad(k_h, (0, 0, 0, 0, 0, pad))\n            v = F.pad(v, (0, 0, 0, 0, 0, pad))\n            g = F.pad(g, (0, 0, 0, pad))\n\n        def chunkify(x: torch.Tensor) -> torch.Tensor:\n            (B, T, H, D) = x.shape\n            return x.reshape(B, num_chunks, cs, H, D).permute(0, 3, 1, 2, 4).reshape(B * H * num_chunks, cs, D)\n        q_blk = chunkify(q_h)\n        k_blk = chunkify(k_h)\n        v_blk = chunkify(v)\n        g_blk = chunkify(g.unsqueeze(-1)).float().squeeze(-1)\n        h_blk = h.permute(0, 2, 1, 3, 4).reshape(batch * num_heads * num_chunks, key_dim, value_dim)\n        o = torch.bmm(q_blk.float(), h_blk.float())\n        attn = torch.bmm(q_blk.float(), k_blk.float().transpose(-2, -1))\n        exp_g = torch.exp(g_blk)\n        o = o * exp_g.unsqueeze(-1)\n        g_diff = g_blk.unsqueeze(-1) - g_blk.unsqueeze(-2)\n        attn = attn * torch.exp(torch.where(g_diff <= 0, g_diff, torch.tensor(float('-inf'), device=g_diff.device)))\n        attn = torch.tril(attn)\n        o_full = (o + torch.bmm(attn.to(v.dtype).float(), v_blk.float())) * scale\n        out = o_full.reshape(batch, num_heads, num_chunks, cs, value_dim).permute(0, 2, 3, 1, 4).reshape(batch, tokens_padded, num_heads, value_dim).to(v.dtype)\n        return out[:, :tokens]\n",
+      "input_code": "import math\nimport torch\n\ndef _make_inputs(batch_size: int, token_count: int, num_q_heads: int, num_v_heads: int, key_dim: int, value_dim: int, chunk_size: int=64) -> dict[str, torch.Tensor]:\n    q = torch.randn(batch_size, token_count, num_q_heads, key_dim, dtype=torch.bfloat16, device='cuda') * 0.02\n    k = torch.randn_like(q)\n    v = torch.randn(batch_size, token_count, num_v_heads, value_dim, dtype=torch.bfloat16, device='cuda') * 0.02\n    num_chunks = math.ceil(token_count / chunk_size)\n    h = torch.randn(batch_size, num_chunks, num_v_heads, key_dim, value_dim, dtype=torch.bfloat16, device='cuda') * 0.02\n    g = -torch.rand(batch_size, token_count, num_v_heads, dtype=torch.float32, device='cuda')\n    return {'q': q, 'k': k, 'v': v, 'h': h, 'g': g}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM TP1), chunk output, tokens=64 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 64,
+            "num_v_heads": 32,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 135266304,
+          "Q_bytes": 2629632,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 0.58,
+            "H20": 0.91
+          },
+          "prod_us": {
+            "XPU-A": 20.2
+          }
+        },
+        "1": {
+          "description": "(vLLM TP1), chunk output, tokens=128 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 128,
+            "num_v_heads": 32,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 270532608,
+          "Q_bytes": 5259264,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 1.16,
+            "H20": 1.83
+          },
+          "prod_us": {
+            "XPU-A": 23.9
+          }
+        },
+        "2": {
+          "description": "(vLLM TP1), chunk output, tokens=256 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 256,
+            "num_v_heads": 32,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 541065216,
+          "Q_bytes": 10518528,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 2.33,
+            "H20": 3.66
+          },
+          "prod_us": {
+            "XPU-A": 37.1
+          }
+        },
+        "3": {
+          "description": "(vLLM TP1), chunk output, tokens=512 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 512,
+            "num_v_heads": 32,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 1082130432,
+          "Q_bytes": 21037056,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 4.65,
+            "H20": 7.31
+          },
+          "prod_us": {
+            "XPU-A": 57.9
+          }
+        },
+        "4": {
+          "description": "(vLLM TP1), chunk output, tokens=1024 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 1024,
+            "num_v_heads": 32,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 2164260864,
+          "Q_bytes": 42074112,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 9.3,
+            "H20": 14.62
+          },
+          "prod_us": {
+            "XPU-A": 97.2
+          }
+        },
+        "5": {
+          "description": "(vLLM TP1), chunk output, tokens=2048 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2048,
+            "num_v_heads": 32,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 4328521728,
+          "Q_bytes": 84148224,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 18.61,
+            "H20": 29.25
+          },
+          "prod_us": {
+            "XPU-A": 190.5
+          }
+        },
+        "6": {
+          "description": "(vLLM TP1), chunk output, tokens=4096 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 4096,
+            "num_v_heads": 32,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 8657043456,
+          "Q_bytes": 168296448,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 37.21,
+            "H20": 58.49
+          },
+          "prod_us": {
+            "XPU-A": 372.9
+          }
+        },
+        "7": {
+          "description": "(vLLM TP1), chunk output, tokens=8192 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 8192,
+            "num_v_heads": 32,
+            "value_dim": 128,
+            "num_q_heads": 16,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 17314086912,
+          "Q_bytes": 336592896,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 74.42,
+            "H20": 116.99
+          },
+          "prod_us": {
+            "XPU-A": 725.5
+          }
+        },
+        "8": {
+          "description": "(SGLang TP8), chunk output, tokens=704 heads=8/16 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 704,
+            "num_v_heads": 16,
+            "value_dim": 128,
+            "num_q_heads": 8,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 743964672,
+          "Q_bytes": 14462976,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 3.2,
+            "H20": 5.03
+          },
+          "prod_us": {
+            "XPU-A": 46.7
+          }
+        },
+        "9": {
+          "description": "(SGLang TP8), chunk output, tokens=1024 heads=8/16 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 1024,
+            "num_v_heads": 16,
+            "value_dim": 128,
+            "num_q_heads": 8,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 1082130432,
+          "Q_bytes": 21037056,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 4.65,
+            "H20": 7.31
+          },
+          "prod_us": {
+            "XPU-A": 59.9
+          }
+        },
+        "10": {
+          "description": "(SGLang TP8), chunk output, tokens=2112 heads=8/16 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 2112,
+            "num_v_heads": 16,
+            "value_dim": 128,
+            "num_q_heads": 8,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 2231894016,
+          "Q_bytes": 43388928,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 9.59,
+            "H20": 15.08
+          },
+          "prod_us": {
+            "XPU-A": 103.1
+          }
+        },
+        "11": {
+          "description": "(SGLang TP8), chunk output, tokens=4096 heads=8/16 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 4096,
+            "num_v_heads": 16,
+            "value_dim": 128,
+            "num_q_heads": 8,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 4328521728,
+          "Q_bytes": 84148224,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 18.61,
+            "H20": 29.25
+          },
+          "prod_us": {
+            "XPU-A": 195.8
+          }
+        },
+        "12": {
+          "description": "(SGLang TP8), chunk output, tokens=8256 heads=8/16 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "token_count": 8256,
+            "num_v_heads": 16,
+            "value_dim": 128,
+            "num_q_heads": 8,
+            "chunk_size": 64,
+            "key_dim": 128,
+            "batch_size": 1
+          },
+          "W_flops": 8724676608,
+          "Q_bytes": 169611264,
+          "ai": 51.4,
+          "SOL_time_ms": {
+            "XPU-A": 37.5,
+            "H20": 58.95
+          },
+          "prod_us": {
+            "XPU-A": 385.0
+          }
+        },
+        "13": {
+          "description": "(SGLang/vLLM), chunk output, tokens=4195 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "batch_size": 1,
+            "token_count": 4195,
+            "num_q_heads": 16,
+            "num_v_heads": 32,
+            "key_dim": 128,
+            "value_dim": 128,
+            "chunk_size": 64
+          },
+          "W_flops": 8927576064,
+          "Q_bytes": 172839296,
+          "ai": 51.7,
+          "SOL_time_ms": {
+            "XPU-A": 38.37,
+            "H20": 60.32
+          },
+          "prod_us": {
+            "XPU-A": 403.6
+          }
+        },
+        "14": {
+          "description": "(SGLang/vLLM), chunk output, tokens=11027 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "batch_size": 1,
+            "token_count": 11027,
+            "num_q_heads": 16,
+            "num_v_heads": 32,
+            "key_dim": 128,
+            "value_dim": 128,
+            "chunk_size": 64
+          },
+          "W_flops": 23401070592,
+          "Q_bytes": 453814656,
+          "ai": 51.6,
+          "SOL_time_ms": {
+            "XPU-A": 100.58,
+            "H20": 158.12
+          },
+          "prod_us": {
+            "XPU-A": 1055.1
+          }
+        },
+        "15": {
+          "description": "(SGLang/vLLM), chunk output, tokens=14807 heads=16/32 dim=128/128",
+          "init_kwargs": {
+            "chunk_size": 64
+          },
+          "input_kwargs": {
+            "batch_size": 1,
+            "token_count": 14807,
+            "num_q_heads": 16,
+            "num_v_heads": 32,
+            "key_dim": 128,
+            "value_dim": 128,
+            "chunk_size": 64
+          },
+          "W_flops": 31381782528,
+          "Q_bytes": 609061760,
+          "ai": 51.5,
+          "SOL_time_ms": {
+            "XPU-A": 134.89,
+            "H20": 212.04
+          },
+          "prod_us": {
+            "XPU-A": 1291.6
+          }
+        }
+      }
+    },
+    {
+      "name": "fp8_dynamic_per_token_quant",
+      "id": "atrex_007",
+      "dtype": "fp8_e4m3",
+      "framework": "rtp-llm",
+      "symbol": "dynamic_per_token_scaled_quant",
+      "module": "aiter.ops.quant",
+      "phase": "prefill/decode",
+      "shapes": 20,
+      "importance": 0.008223,
+      "roofline": {
+        "median_ai": 0.3,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 2049,
+          "Q_bytes": 6148,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(1,2048)"
+        },
+        "1": {
+          "W_flops": 1245792,
+          "Q_bytes": 3737984,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.71,
+            "H20": 0.93
+          },
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(608,2048)"
+        },
+        "2": {
+          "W_flops": 1772385,
+          "Q_bytes": 5318020,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 1.0,
+            "H20": 1.33
+          },
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(865,2048)"
+        },
+        "3": {
+          "W_flops": 4163568,
+          "Q_bytes": 12492736,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 2.36,
+            "H20": 3.12
+          },
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(2032,2048)"
+        },
+        "4": {
+          "W_flops": 8491056,
+          "Q_bytes": 25477312,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 4.81,
+            "H20": 6.37
+          },
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(4144,2048)"
+        },
+        "5": {
+          "W_flops": 14179080,
+          "Q_bytes": 42544160,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 8.03,
+            "H20": 10.64
+          },
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(6920,2048)"
+        },
+        "6": {
+          "W_flops": 33308544,
+          "Q_bytes": 99941888,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 18.86,
+            "H20": 24.99
+          },
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(16256,2048)"
+        },
+        "7": {
+          "W_flops": 50634888,
+          "Q_bytes": 151929376,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 28.67,
+            "H20": 37.98
+          },
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(24712,2048)"
+        },
+        "8": {
+          "W_flops": 93368832,
+          "Q_bytes": 280152064,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 52.86,
+            "H20": 70.04
+          },
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(45568,2048)"
+        },
+        "10": {
+          "W_flops": 4097,
+          "Q_bytes": 12292,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(1,4096)"
+        },
+        "11": {
+          "W_flops": 520319,
+          "Q_bytes": 1561084,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.29,
+            "H20": 0.39
+          },
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(127,4096)"
+        },
+        "12": {
+          "W_flops": 1044735,
+          "Q_bytes": 3134460,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.59,
+            "H20": 0.78
+          },
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(255,4096)"
+        },
+        "13": {
+          "W_flops": 2101761,
+          "Q_bytes": 6305796,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 1.19,
+            "H20": 1.58
+          },
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(513,4096)"
+        },
+        "14": {
+          "W_flops": 4215813,
+          "Q_bytes": 12648468,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 2.39,
+            "H20": 3.16
+          },
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(1029,4096)"
+        },
+        "15": {
+          "W_flops": 8361977,
+          "Q_bytes": 25087972,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 4.73,
+            "H20": 6.27
+          },
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(2041,4096)"
+        },
+        "16": {
+          "W_flops": 16814088,
+          "Q_bytes": 50446368,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 9.52,
+            "H20": 12.61
+          },
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(4104,4096)"
+        },
+        "17": {
+          "W_flops": 33628176,
+          "Q_bytes": 100892736,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 19.04,
+            "H20": 25.22
+          },
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(8208,4096)"
+        },
+        "18": {
+          "W_flops": 5121,
+          "Q_bytes": 15364,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(rtp-llm TP2), FP8 dynamic per-token quantization, input=(1,5120)"
+        },
+        "19": {
+          "W_flops": 12101272,
+          "Q_bytes": 36305504,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 6.85,
+            "H20": 9.08
+          },
+          "description": "(SGLang/vLLM), FP8 dynamic per-token quantization, input=(1688,7168)"
+        },
+        "20": {
+          "W_flops": 27270876,
+          "Q_bytes": 81816432,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 15.44,
+            "H20": 20.45
+          },
+          "description": "(SGLang/vLLM), FP8 dynamic per-token quantization, input=(3804,7168)"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 20,
+          "median_us": 17.5,
+          "min_us": 7.6,
+          "max_us": 183.5,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 7.6,
+          "1": 8.2,
+          "2": 9.1,
+          "3": 14.0,
+          "4": 21.4,
+          "5": 31.9,
+          "6": 73.6,
+          "7": 105.7,
+          "8": 183.5,
+          "10": 7.6,
+          "11": 7.7,
+          "12": 7.9,
+          "13": 9.3,
+          "14": 11.9,
+          "15": 17.5,
+          "16": 28.7,
+          "17": 51.9,
+          "18": 7.6,
+          "19": 22.0,
+          "20": 42.4
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self) -> None:\n        super().__init__()\n        self.finfo = torch.finfo(torch.float8_e4m3fnuz)\n\n    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:\n        x_float = x.to(torch.float32)\n        row_absmax = x_float.abs().amax(dim=-1, keepdim=True).clamp(min=1e-12)\n        scale = row_absmax / self.finfo.max\n        inv_scale = scale.reciprocal()\n        q = (x_float * inv_scale).clamp(min=self.finfo.min, max=self.finfo.max)\n        return (q.to(torch.float8_e4m3fnuz), scale.squeeze(-1))\n",
+      "input_code": "import torch\n\n\ndef _make_inputs(token_count: int, hidden_size: int) -> dict[str, torch.Tensor]:\n    x = torch.randn(token_count, hidden_size, dtype=torch.bfloat16, device='cuda')\n    return {'x': x}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(1,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 1,
+            "hidden_size": 2048
+          },
+          "W_flops": 2049,
+          "Q_bytes": 6148,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 7.6
+          }
+        },
+        "1": {
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(608,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 608,
+            "hidden_size": 2048
+          },
+          "W_flops": 1245792,
+          "Q_bytes": 3737984,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.71,
+            "H20": 0.93
+          },
+          "prod_us": {
+            "XPU-A": 8.2
+          }
+        },
+        "2": {
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(865,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 865,
+            "hidden_size": 2048
+          },
+          "W_flops": 1772385,
+          "Q_bytes": 5318020,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 1.0,
+            "H20": 1.33
+          },
+          "prod_us": {
+            "XPU-A": 9.1
+          }
+        },
+        "3": {
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(2032,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 2032,
+            "hidden_size": 2048
+          },
+          "W_flops": 4163568,
+          "Q_bytes": 12492736,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 2.36,
+            "H20": 3.12
+          },
+          "prod_us": {
+            "XPU-A": 14.0
+          }
+        },
+        "4": {
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(4144,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 4144,
+            "hidden_size": 2048
+          },
+          "W_flops": 8491056,
+          "Q_bytes": 25477312,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 4.81,
+            "H20": 6.37
+          },
+          "prod_us": {
+            "XPU-A": 21.4
+          }
+        },
+        "5": {
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(6920,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 6920,
+            "hidden_size": 2048
+          },
+          "W_flops": 14179080,
+          "Q_bytes": 42544160,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 8.03,
+            "H20": 10.64
+          },
+          "prod_us": {
+            "XPU-A": 31.9
+          }
+        },
+        "6": {
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(16256,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 16256,
+            "hidden_size": 2048
+          },
+          "W_flops": 33308544,
+          "Q_bytes": 99941888,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 18.86,
+            "H20": 24.99
+          },
+          "prod_us": {
+            "XPU-A": 73.6
+          }
+        },
+        "7": {
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(24712,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 24712,
+            "hidden_size": 2048
+          },
+          "W_flops": 50634888,
+          "Q_bytes": 151929376,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 28.67,
+            "H20": 37.98
+          },
+          "prod_us": {
+            "XPU-A": 105.7
+          }
+        },
+        "8": {
+          "description": "(vLLM TP1), FP8 dynamic per-token quantization, input=(45568,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 45568,
+            "hidden_size": 2048
+          },
+          "W_flops": 93368832,
+          "Q_bytes": 280152064,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 52.86,
+            "H20": 70.04
+          },
+          "prod_us": {
+            "XPU-A": 183.5
+          }
+        },
+        "10": {
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(1,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 1,
+            "hidden_size": 4096
+          },
+          "W_flops": 4097,
+          "Q_bytes": 12292,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 7.6
+          }
+        },
+        "11": {
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(127,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 127,
+            "hidden_size": 4096
+          },
+          "W_flops": 520319,
+          "Q_bytes": 1561084,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.29,
+            "H20": 0.39
+          },
+          "prod_us": {
+            "XPU-A": 7.7
+          }
+        },
+        "12": {
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(255,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 255,
+            "hidden_size": 4096
+          },
+          "W_flops": 1044735,
+          "Q_bytes": 3134460,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.59,
+            "H20": 0.78
+          },
+          "prod_us": {
+            "XPU-A": 7.9
+          }
+        },
+        "13": {
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(513,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 513,
+            "hidden_size": 4096
+          },
+          "W_flops": 2101761,
+          "Q_bytes": 6305796,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 1.19,
+            "H20": 1.58
+          },
+          "prod_us": {
+            "XPU-A": 9.3
+          }
+        },
+        "14": {
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(1029,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 1029,
+            "hidden_size": 4096
+          },
+          "W_flops": 4215813,
+          "Q_bytes": 12648468,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 2.39,
+            "H20": 3.16
+          },
+          "prod_us": {
+            "XPU-A": 11.9
+          }
+        },
+        "15": {
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(2041,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 2041,
+            "hidden_size": 4096
+          },
+          "W_flops": 8361977,
+          "Q_bytes": 25087972,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 4.73,
+            "H20": 6.27
+          },
+          "prod_us": {
+            "XPU-A": 17.5
+          }
+        },
+        "16": {
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(4104,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 4104,
+            "hidden_size": 4096
+          },
+          "W_flops": 16814088,
+          "Q_bytes": 50446368,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 9.52,
+            "H20": 12.61
+          },
+          "prod_us": {
+            "XPU-A": 28.7
+          }
+        },
+        "17": {
+          "description": "(SGLang TP8), FP8 dynamic per-token quantization, input=(8208,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 8208,
+            "hidden_size": 4096
+          },
+          "W_flops": 33628176,
+          "Q_bytes": 100892736,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 19.04,
+            "H20": 25.22
+          },
+          "prod_us": {
+            "XPU-A": 51.9
+          }
+        },
+        "18": {
+          "description": "(rtp-llm TP2), FP8 dynamic per-token quantization, input=(1,5120)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 1,
+            "hidden_size": 5120
+          },
+          "W_flops": 5121,
+          "Q_bytes": 15364,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 7.6
+          }
+        },
+        "19": {
+          "description": "(SGLang/vLLM), FP8 dynamic per-token quantization, input=(1688,7168)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 1688,
+            "hidden_size": 7168
+          },
+          "W_flops": 12101272,
+          "Q_bytes": 36305504,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 6.85,
+            "H20": 9.08
+          },
+          "prod_us": {
+            "XPU-A": 22.0
+          }
+        },
+        "20": {
+          "description": "(SGLang/vLLM), FP8 dynamic per-token quantization, input=(3804,7168)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 3804,
+            "hidden_size": 7168
+          },
+          "W_flops": 27270876,
+          "Q_bytes": 81816432,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 15.44,
+            "H20": 20.45
+          },
+          "prod_us": {
+            "XPU-A": 42.4
+          }
+        }
+      }
+    },
+    {
+      "name": "linear_sigmoid_mul",
+      "id": "atrex_017",
+      "dtype": "bf16",
+      "framework": "sglang",
+      "symbol": "sgl_kernel.fused_linear_sigmoid_mul",
+      "module": "sglang.srt.models.qwen2_moe",
+      "phase": "prefill/decode",
+      "shapes": 9,
+      "importance": 0.007234,
+      "roofline": {
+        "median_ai": 1018.0,
+        "regime": "compute-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 269709889536,
+          "Q_bytes": 231079936,
+          "ai": 1167.2,
+          "SOL_time_ms": {
+            "XPU-A": 1159.29,
+            "H20": 1822.36
+          },
+          "description": "(SGLang TP inferred), shared expert gate, hidden_states=(8037,4096) out=4096"
+        },
+        "1": {
+          "W_flops": 225412632576,
+          "Q_bytes": 198639616,
+          "ai": 1134.8,
+          "SOL_time_ms": {
+            "XPU-A": 968.89,
+            "H20": 1523.06
+          },
+          "description": "(SGLang TP inferred), shared expert gate, hidden_states=(6717,4096) out=4096"
+        },
+        "2": {
+          "W_flops": 134267670528,
+          "Q_bytes": 131891200,
+          "ai": 1018.0,
+          "SOL_time_ms": {
+            "XPU-A": 577.12,
+            "H20": 907.21
+          },
+          "description": "(SGLang TP inferred), shared expert gate, hidden_states=(4001,4096) out=4096"
+        },
+        "3": {
+          "W_flops": 516163719168,
+          "Q_bytes": 411566080,
+          "ai": 1254.1,
+          "SOL_time_ms": {
+            "XPU-A": 2218.63,
+            "H20": 3487.59
+          },
+          "description": "(SGLang TP inferred), shared expert gate, hidden_states=(15381,4096) out=4096"
+        },
+        "4": {
+          "W_flops": 220680880128,
+          "Q_bytes": 195174400,
+          "ai": 1130.7,
+          "SOL_time_ms": {
+            "XPU-A": 948.55,
+            "H20": 1491.09
+          },
+          "description": "(SGLang TP inferred), shared expert gate, hidden_states=(6576,4096) out=4096"
+        },
+        "5": {
+          "W_flops": 16781312,
+          "Q_bytes": 16805888,
+          "ai": 1.0,
+          "SOL_time_ms": {
+            "XPU-A": 3.17,
+            "H20": 4.2
+          },
+          "description": "(SGLang TP1), shared expert gate, hidden_states=(1,2048) out=2048"
+        },
+        "6": {
+          "W_flops": 1510318080,
+          "Q_bytes": 18628608,
+          "ai": 81.1,
+          "SOL_time_ms": {
+            "XPU-A": 6.49,
+            "H20": 10.2
+          },
+          "description": "(SGLang TP1), shared expert gate, hidden_states=(90,2048) out=2048"
+        },
+        "7": {
+          "W_flops": 218157056,
+          "Q_bytes": 17051648,
+          "ai": 12.8,
+          "SOL_time_ms": {
+            "XPU-A": 3.22,
+            "H20": 4.26
+          },
+          "description": "(SGLang TP1), shared expert gate, hidden_states=(13,2048) out=2048"
+        },
+        "8": {
+          "W_flops": 92218834944,
+          "Q_bytes": 101097472,
+          "ai": 912.2,
+          "SOL_time_ms": {
+            "XPU-A": 396.38,
+            "H20": 623.1
+          },
+          "description": "(SGLang TP8), shared expert gate, hidden_states=(2748,4096) out=4096"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 9,
+          "median_us": 1260.5,
+          "min_us": 17.3,
+          "max_us": 7205.3,
+          "framework": "sglang"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 1604.4,
+          "1": 1265.8,
+          "2": 2059.3,
+          "3": 7205.3,
+          "4": 1260.5,
+          "5": 20.9,
+          "6": 32.2,
+          "7": 17.3,
+          "8": 564.5
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self) -> None:\n        super().__init__()\n\n    def forward(self, hidden_states: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor, post_mul_mat: torch.Tensor) -> torch.Tensor:\n        gate = F.linear(hidden_states, weight, bias)\n        out = torch.sigmoid(gate.float()) * post_mul_mat.float()\n        return out.to(post_mul_mat.dtype)\n",
+      "input_code": "import torch\n\ndef _make_inputs(token_count: int, hidden_size: int, out_features: int) -> dict[str, torch.Tensor]:\n    hidden_states = torch.randn(token_count, hidden_size, dtype=torch.bfloat16, device='cuda') * 0.02\n    weight = torch.randn(out_features, hidden_size, dtype=torch.bfloat16, device='cuda') * hidden_size ** (-0.5)\n    bias = torch.randn(out_features, dtype=torch.bfloat16, device='cuda') * 0.02\n    post_mul_mat = torch.randn(token_count, out_features, dtype=torch.bfloat16, device='cuda') * 0.02\n    return {'hidden_states': hidden_states, 'weight': weight, 'bias': bias, 'post_mul_mat': post_mul_mat}\n",
+      "shape_details": {
+        "0": {
+          "description": "(SGLang TP inferred), shared expert gate, hidden_states=(8037,4096) out=4096",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 8037,
+            "hidden_size": 4096,
+            "out_features": 4096
+          },
+          "W_flops": 269709889536,
+          "Q_bytes": 231079936,
+          "ai": 1167.2,
+          "SOL_time_ms": {
+            "XPU-A": 1159.29,
+            "H20": 1822.36
+          },
+          "prod_us": {
+            "XPU-A": 1604.4
+          }
+        },
+        "1": {
+          "description": "(SGLang TP inferred), shared expert gate, hidden_states=(6717,4096) out=4096",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 6717,
+            "hidden_size": 4096,
+            "out_features": 4096
+          },
+          "W_flops": 225412632576,
+          "Q_bytes": 198639616,
+          "ai": 1134.8,
+          "SOL_time_ms": {
+            "XPU-A": 968.89,
+            "H20": 1523.06
+          },
+          "prod_us": {
+            "XPU-A": 1265.8
+          }
+        },
+        "2": {
+          "description": "(SGLang TP inferred), shared expert gate, hidden_states=(4001,4096) out=4096",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 4001,
+            "hidden_size": 4096,
+            "out_features": 4096
+          },
+          "W_flops": 134267670528,
+          "Q_bytes": 131891200,
+          "ai": 1018.0,
+          "SOL_time_ms": {
+            "XPU-A": 577.12,
+            "H20": 907.21
+          },
+          "prod_us": {
+            "XPU-A": 2059.3
+          }
+        },
+        "3": {
+          "description": "(SGLang TP inferred), shared expert gate, hidden_states=(15381,4096) out=4096",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 15381,
+            "hidden_size": 4096,
+            "out_features": 4096
+          },
+          "W_flops": 516163719168,
+          "Q_bytes": 411566080,
+          "ai": 1254.1,
+          "SOL_time_ms": {
+            "XPU-A": 2218.63,
+            "H20": 3487.59
+          },
+          "prod_us": {
+            "XPU-A": 7205.3
+          }
+        },
+        "4": {
+          "description": "(SGLang TP inferred), shared expert gate, hidden_states=(6576,4096) out=4096",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 6576,
+            "hidden_size": 4096,
+            "out_features": 4096
+          },
+          "W_flops": 220680880128,
+          "Q_bytes": 195174400,
+          "ai": 1130.7,
+          "SOL_time_ms": {
+            "XPU-A": 948.55,
+            "H20": 1491.09
+          },
+          "prod_us": {
+            "XPU-A": 1260.5
+          }
+        },
+        "5": {
+          "description": "(SGLang TP1), shared expert gate, hidden_states=(1,2048) out=2048",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 1,
+            "hidden_size": 2048,
+            "out_features": 4096
+          },
+          "W_flops": 16781312,
+          "Q_bytes": 16805888,
+          "ai": 1.0,
+          "SOL_time_ms": {
+            "XPU-A": 3.17,
+            "H20": 4.2
+          },
+          "prod_us": {
+            "XPU-A": 20.9
+          }
+        },
+        "6": {
+          "description": "(SGLang TP1), shared expert gate, hidden_states=(90,2048) out=2048",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 90,
+            "hidden_size": 2048,
+            "out_features": 4096
+          },
+          "W_flops": 1510318080,
+          "Q_bytes": 18628608,
+          "ai": 81.1,
+          "SOL_time_ms": {
+            "XPU-A": 6.49,
+            "H20": 10.2
+          },
+          "prod_us": {
+            "XPU-A": 32.2
+          }
+        },
+        "7": {
+          "description": "(SGLang TP1), shared expert gate, hidden_states=(13,2048) out=2048",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 13,
+            "hidden_size": 2048,
+            "out_features": 4096
+          },
+          "W_flops": 218157056,
+          "Q_bytes": 17051648,
+          "ai": 12.8,
+          "SOL_time_ms": {
+            "XPU-A": 3.22,
+            "H20": 4.26
+          },
+          "prod_us": {
+            "XPU-A": 17.3
+          }
+        },
+        "8": {
+          "description": "(SGLang TP8), shared expert gate, hidden_states=(2748,4096) out=4096",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 2748,
+            "hidden_size": 4096,
+            "out_features": 4096
+          },
+          "W_flops": 92218834944,
+          "Q_bytes": 101097472,
+          "ai": 912.2,
+          "SOL_time_ms": {
+            "XPU-A": 396.38,
+            "H20": 623.1
+          },
+          "prod_us": {
+            "XPU-A": 564.5
+          }
+        }
+      }
+    },
+    {
+      "name": "per_token_group_quant_fp8",
+      "id": "atrex_025",
+      "dtype": "fp8_e4m3",
+      "framework": "vllm",
+      "symbol": "per_token_group_quant_fp8",
+      "module": "vllm.model_executor.layers.quantization.utils.fp8_utils",
+      "phase": "prefill/decode",
+      "shapes": 19,
+      "importance": 0.005308,
+      "roofline": {
+        "median_ai": 0.3,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 2064,
+          "Q_bytes": 6208,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(1,2048) group_size=128"
+        },
+        "1": {
+          "W_flops": 77408256,
+          "Q_bytes": 232824832,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 43.93,
+            "H20": 58.21
+          },
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(37504,2048) group_size=128"
+        },
+        "2": {
+          "W_flops": 154816512,
+          "Q_bytes": 465649664,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 87.86,
+            "H20": 116.41
+          },
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(75008,2048) group_size=128"
+        },
+        "3": {
+          "W_flops": 176744448,
+          "Q_bytes": 531603456,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 100.3,
+            "H20": 132.9
+          },
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(85632,2048) group_size=128"
+        },
+        "4": {
+          "W_flops": 264588288,
+          "Q_bytes": 795815936,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 150.15,
+            "H20": 198.95
+          },
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(128192,2048) group_size=128"
+        },
+        "5": {
+          "W_flops": 530233344,
+          "Q_bytes": 1594810368,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 300.91,
+            "H20": 398.7
+          },
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(256896,2048) group_size=128"
+        },
+        "6": {
+          "W_flops": 1033519104,
+          "Q_bytes": 3108569088,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 586.52,
+            "H20": 777.14
+          },
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(500736,2048) group_size=128"
+        },
+        "7": {
+          "W_flops": 2123971584,
+          "Q_bytes": 6388379648,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 1205.35,
+            "H20": 1597.09
+          },
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(1029056,2048) group_size=128"
+        },
+        "8": {
+          "W_flops": 4247943168,
+          "Q_bytes": 12776759296,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 2410.71,
+            "H20": 3194.19
+          },
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(2058112,2048) group_size=128"
+        },
+        "9": {
+          "W_flops": 6371914752,
+          "Q_bytes": 19165138944,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 3616.06,
+            "H20": 4791.28
+          },
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(3087168,2048) group_size=128"
+        },
+        "10": {
+          "W_flops": 7224,
+          "Q_bytes": 21728,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.01
+          },
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(1,7168) group_size=128"
+        },
+        "11": {
+          "W_flops": 5244624,
+          "Q_bytes": 15774528,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 2.98,
+            "H20": 3.94
+          },
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(726,7168) group_size=128"
+        },
+        "12": {
+          "W_flops": 7000056,
+          "Q_bytes": 21054432,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 3.97,
+            "H20": 5.26
+          },
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(969,7168) group_size=128"
+        },
+        "13": {
+          "W_flops": 13963992,
+          "Q_bytes": 42000224,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 7.92,
+            "H20": 10.5
+          },
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(1933,7168) group_size=128"
+        },
+        "14": {
+          "W_flops": 30283008,
+          "Q_bytes": 91083776,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 17.19,
+            "H20": 22.77
+          },
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(4192,7168) group_size=128"
+        },
+        "15": {
+          "W_flops": 62610408,
+          "Q_bytes": 188316576,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 35.53,
+            "H20": 47.08
+          },
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(8667,7168) group_size=128"
+        },
+        "16": {
+          "W_flops": 121132032,
+          "Q_bytes": 364335104,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 68.74,
+            "H20": 91.08
+          },
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(16768,7168) group_size=128"
+        },
+        "17": {
+          "W_flops": 292196352,
+          "Q_bytes": 878854144,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 165.82,
+            "H20": 219.71
+          },
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(40448,7168) group_size=128"
+        },
+        "18": {
+          "W_flops": 423962112,
+          "Q_bytes": 1275172864,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 240.6,
+            "H20": 318.79
+          },
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(58688,7168) group_size=128"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 19,
+          "median_us": 199.6,
+          "min_us": 7.6,
+          "max_us": 7125.7,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 7.6,
+          "1": 106.1,
+          "2": 199.6,
+          "3": 223.3,
+          "4": 325.7,
+          "5": 639.8,
+          "6": 1258.4,
+          "7": 2622.2,
+          "8": 5328.0,
+          "9": 7125.7,
+          "10": 7.6,
+          "11": 13.9,
+          "12": 15.6,
+          "13": 23.1,
+          "14": 47.6,
+          "15": 91.5,
+          "16": 154.1,
+          "17": 355.8,
+          "18": 515.1
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self, group_size: int) -> None:\n        super().__init__()\n        self.group_size = group_size\n\n    def forward(self, x: torch.Tensor) -> dict[str, torch.Tensor]:\n        (m, n) = x.shape\n        if getattr(torch.version, 'hip', None) and hasattr(torch, 'float8_e4m3fnuz'):\n            fp8_dtype = torch.float8_e4m3fnuz\n            fp8_max = 224.0\n        else:\n            fp8_dtype = torch.float8_e4m3fn\n            fp8_max = torch.finfo(torch.float8_e4m3fn).max\n        x_fp32 = x.float()\n        x_groups = x_fp32.view(m, n // self.group_size, self.group_size)\n        x_abs_max = x_groups.abs().amax(dim=-1)\n        scales = torch.clamp(x_abs_max / fp8_max, min=1e-10)\n        quantized = (x_fp32 / scales.repeat_interleave(self.group_size, dim=1)).clamp(-fp8_max, fp8_max).to(fp8_dtype)\n        return {'quantized': quantized, 'scales': scales}\n",
+      "input_code": "import torch\n\n\ndef _make_inputs(token_count: int, hidden_size: int) -> dict[str, torch.Tensor]:\n    x = torch.randn(token_count, hidden_size, dtype=torch.bfloat16, device='cuda')\n    return {'x': x}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(1,2048) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "hidden_size": 2048
+          },
+          "W_flops": 2064,
+          "Q_bytes": 6208,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 7.6
+          }
+        },
+        "1": {
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(37504,2048) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 37504,
+            "hidden_size": 2048
+          },
+          "W_flops": 77408256,
+          "Q_bytes": 232824832,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 43.93,
+            "H20": 58.21
+          },
+          "prod_us": {
+            "XPU-A": 106.1
+          }
+        },
+        "2": {
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(75008,2048) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 75008,
+            "hidden_size": 2048
+          },
+          "W_flops": 154816512,
+          "Q_bytes": 465649664,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 87.86,
+            "H20": 116.41
+          },
+          "prod_us": {
+            "XPU-A": 199.6
+          }
+        },
+        "3": {
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(85632,2048) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 85632,
+            "hidden_size": 2048
+          },
+          "W_flops": 176744448,
+          "Q_bytes": 531603456,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 100.3,
+            "H20": 132.9
+          },
+          "prod_us": {
+            "XPU-A": 223.3
+          }
+        },
+        "4": {
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(128192,2048) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 128192,
+            "hidden_size": 2048
+          },
+          "W_flops": 264588288,
+          "Q_bytes": 795815936,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 150.15,
+            "H20": 198.95
+          },
+          "prod_us": {
+            "XPU-A": 325.7
+          }
+        },
+        "5": {
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(256896,2048) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 256896,
+            "hidden_size": 2048
+          },
+          "W_flops": 530233344,
+          "Q_bytes": 1594810368,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 300.91,
+            "H20": 398.7
+          },
+          "prod_us": {
+            "XPU-A": 639.8
+          }
+        },
+        "6": {
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(500736,2048) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 500736,
+            "hidden_size": 2048
+          },
+          "W_flops": 1033519104,
+          "Q_bytes": 3108569088,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 586.52,
+            "H20": 777.14
+          },
+          "prod_us": {
+            "XPU-A": 1258.4
+          }
+        },
+        "7": {
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(1029056,2048) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 1029056,
+            "hidden_size": 2048
+          },
+          "W_flops": 2123971584,
+          "Q_bytes": 6388379648,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 1205.35,
+            "H20": 1597.09
+          },
+          "prod_us": {
+            "XPU-A": 2622.2
+          }
+        },
+        "8": {
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(2058112,2048) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 2058112,
+            "hidden_size": 2048
+          },
+          "W_flops": 4247943168,
+          "Q_bytes": 12776759296,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 2410.71,
+            "H20": 3194.19
+          },
+          "prod_us": {
+            "XPU-A": 5328.0
+          }
+        },
+        "9": {
+          "description": "(vLLM TP1), FP8 per-token-group quantization, input=(3087168,2048) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 3087168,
+            "hidden_size": 2048
+          },
+          "W_flops": 6371914752,
+          "Q_bytes": 19165138944,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 3616.06,
+            "H20": 4791.28
+          },
+          "prod_us": {
+            "XPU-A": 7125.7
+          }
+        },
+        "10": {
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(1,7168) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "hidden_size": 7168
+          },
+          "W_flops": 7224,
+          "Q_bytes": 21728,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 7.6
+          }
+        },
+        "11": {
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(726,7168) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 726,
+            "hidden_size": 7168
+          },
+          "W_flops": 5244624,
+          "Q_bytes": 15774528,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 2.98,
+            "H20": 3.94
+          },
+          "prod_us": {
+            "XPU-A": 13.9
+          }
+        },
+        "12": {
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(969,7168) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 969,
+            "hidden_size": 7168
+          },
+          "W_flops": 7000056,
+          "Q_bytes": 21054432,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 3.97,
+            "H20": 5.26
+          },
+          "prod_us": {
+            "XPU-A": 15.6
+          }
+        },
+        "13": {
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(1933,7168) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 1933,
+            "hidden_size": 7168
+          },
+          "W_flops": 13963992,
+          "Q_bytes": 42000224,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 7.92,
+            "H20": 10.5
+          },
+          "prod_us": {
+            "XPU-A": 23.1
+          }
+        },
+        "14": {
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(4192,7168) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 4192,
+            "hidden_size": 7168
+          },
+          "W_flops": 30283008,
+          "Q_bytes": 91083776,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 17.19,
+            "H20": 22.77
+          },
+          "prod_us": {
+            "XPU-A": 47.6
+          }
+        },
+        "15": {
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(8667,7168) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 8667,
+            "hidden_size": 7168
+          },
+          "W_flops": 62610408,
+          "Q_bytes": 188316576,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 35.53,
+            "H20": 47.08
+          },
+          "prod_us": {
+            "XPU-A": 91.5
+          }
+        },
+        "16": {
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(16768,7168) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 16768,
+            "hidden_size": 7168
+          },
+          "W_flops": 121132032,
+          "Q_bytes": 364335104,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 68.74,
+            "H20": 91.08
+          },
+          "prod_us": {
+            "XPU-A": 154.1
+          }
+        },
+        "17": {
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(40448,7168) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 40448,
+            "hidden_size": 7168
+          },
+          "W_flops": 292196352,
+          "Q_bytes": 878854144,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 165.82,
+            "H20": 219.71
+          },
+          "prod_us": {
+            "XPU-A": 355.8
+          }
+        },
+        "18": {
+          "description": "(SGLang TP8), FP8 per-token-group quantization, input=(58688,7168) group_size=128",
+          "init_kwargs": {
+            "group_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 58688,
+            "hidden_size": 7168
+          },
+          "W_flops": 423962112,
+          "Q_bytes": 1275172864,
+          "ai": 0.3,
+          "SOL_time_ms": {
+            "XPU-A": 240.6,
+            "H20": 318.79
+          },
+          "prod_us": {
+            "XPU-A": 515.1
+          }
+        }
+      }
+    },
+    {
+      "name": "gated_rms_norm",
+      "id": "atrex_014",
+      "dtype": "bf16",
+      "framework": "sglang",
+      "symbol": "rms_norm_gated",
+      "module": "sglang.srt.layers.attention.fla.layernorm_gated",
+      "phase": "prefill/decode",
+      "shapes": 7,
+      "importance": 0.004735,
+      "roofline": {
+        "median_ai": 1.3,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 361685600,
+          "Q_bytes": 270999808,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 51.13,
+            "H20": 67.75
+          },
+          "description": "(SGLang), gated RMSNorm, rows=352864 hidden=128"
+        },
+        "1": {
+          "W_flops": 197784000,
+          "Q_bytes": 148193536,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 27.96,
+            "H20": 37.05
+          },
+          "description": "(SGLang), gated RMSNorm, rows=192960 hidden=128"
+        },
+        "2": {
+          "W_flops": 196242400,
+          "Q_bytes": 147038464,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 27.74,
+            "H20": 36.76
+          },
+          "description": "(SGLang), gated RMSNorm, rows=191456 hidden=128"
+        },
+        "3": {
+          "W_flops": 165410400,
+          "Q_bytes": 123937024,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 23.38,
+            "H20": 30.98
+          },
+          "description": "(SGLang), gated RMSNorm, rows=161376 hidden=128"
+        },
+        "4": {
+          "W_flops": 163868800,
+          "Q_bytes": 122781952,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 23.17,
+            "H20": 30.7
+          },
+          "description": "(SGLang), gated RMSNorm, rows=159872 hidden=128"
+        },
+        "5": {
+          "W_flops": 143106400,
+          "Q_bytes": 107225344,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 20.23,
+            "H20": 26.81
+          },
+          "description": "(SGLang), gated RMSNorm, rows=139616 hidden=128"
+        },
+        "6": {
+          "W_flops": 137596000,
+          "Q_bytes": 103096576,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 19.45,
+            "H20": 25.77
+          },
+          "description": "(SGLang), gated RMSNorm, rows=134240 hidden=128"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 7,
+          "median_us": 119.7,
+          "min_us": 100.0,
+          "max_us": 248.7,
+          "framework": "sglang"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 248.7,
+          "1": 141.1,
+          "2": 140.0,
+          "3": 119.7,
+          "4": 118.7,
+          "5": 104.4,
+          "6": 100.0
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self, eps: float=1e-06, norm_before_gate: bool=True, activation: str='silu') -> None:\n        super().__init__()\n        self.eps = float(eps)\n        self.norm_before_gate = bool(norm_before_gate)\n        self.activation = activation\n\n    def forward(self, x: torch.Tensor, weight: torch.Tensor, z: torch.Tensor) -> torch.Tensor:\n        dtype = x.dtype\n        x_f = x.float()\n        z_f = z.float()\n        if not self.norm_before_gate:\n            x_f = x_f * self._activate(z_f)\n        rstd = torch.rsqrt(x_f.square().mean(dim=-1, keepdim=True) + self.eps)\n        out = x_f * rstd * weight.float()\n        if self.norm_before_gate:\n            out = out * self._activate(z_f)\n        return out.to(dtype)\n\n    def _activate(self, z: torch.Tensor) -> torch.Tensor:\n        if self.activation in ('silu', 'swish'):\n            return F.silu(z)\n        if self.activation == 'sigmoid':\n            return torch.sigmoid(z)\n        raise ValueError(f'unsupported activation: {self.activation}')\n",
+      "input_code": "import torch\n\ndef _make_inputs(rows: int, hidden_size: int) -> dict[str, torch.Tensor]:\n    x = torch.randn(rows, hidden_size, dtype=torch.bfloat16, device='cuda') * 0.02\n    weight = torch.randn(hidden_size, dtype=torch.bfloat16, device='cuda') * 0.02 + 1.0\n    z = torch.randn_like(x)\n    return {'x': x, 'weight': weight, 'z': z}\n",
+      "shape_details": {
+        "0": {
+          "description": "(SGLang), gated RMSNorm, rows=352864 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06,
+            "norm_before_gate": true,
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "rows": 352864,
+            "hidden_size": 128
+          },
+          "W_flops": 361685600,
+          "Q_bytes": 270999808,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 51.13,
+            "H20": 67.75
+          },
+          "prod_us": {
+            "XPU-A": 248.7
+          }
+        },
+        "1": {
+          "description": "(SGLang), gated RMSNorm, rows=192960 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06,
+            "norm_before_gate": true,
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "rows": 192960,
+            "hidden_size": 128
+          },
+          "W_flops": 197784000,
+          "Q_bytes": 148193536,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 27.96,
+            "H20": 37.05
+          },
+          "prod_us": {
+            "XPU-A": 141.1
+          }
+        },
+        "2": {
+          "description": "(SGLang), gated RMSNorm, rows=191456 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06,
+            "norm_before_gate": true,
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "rows": 191456,
+            "hidden_size": 128
+          },
+          "W_flops": 196242400,
+          "Q_bytes": 147038464,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 27.74,
+            "H20": 36.76
+          },
+          "prod_us": {
+            "XPU-A": 140.0
+          }
+        },
+        "3": {
+          "description": "(SGLang), gated RMSNorm, rows=161376 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06,
+            "norm_before_gate": true,
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "rows": 161376,
+            "hidden_size": 128
+          },
+          "W_flops": 165410400,
+          "Q_bytes": 123937024,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 23.38,
+            "H20": 30.98
+          },
+          "prod_us": {
+            "XPU-A": 119.7
+          }
+        },
+        "4": {
+          "description": "(SGLang), gated RMSNorm, rows=159872 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06,
+            "norm_before_gate": true,
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "rows": 159872,
+            "hidden_size": 128
+          },
+          "W_flops": 163868800,
+          "Q_bytes": 122781952,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 23.17,
+            "H20": 30.7
+          },
+          "prod_us": {
+            "XPU-A": 118.7
+          }
+        },
+        "5": {
+          "description": "(SGLang), gated RMSNorm, rows=139616 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06,
+            "norm_before_gate": true,
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "rows": 139616,
+            "hidden_size": 128
+          },
+          "W_flops": 143106400,
+          "Q_bytes": 107225344,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 20.23,
+            "H20": 26.81
+          },
+          "prod_us": {
+            "XPU-A": 104.4
+          }
+        },
+        "6": {
+          "description": "(SGLang), gated RMSNorm, rows=134240 hidden=128",
+          "init_kwargs": {
+            "eps": 1e-06,
+            "norm_before_gate": true,
+            "activation": "silu"
+          },
+          "input_kwargs": {
+            "rows": 134240,
+            "hidden_size": 128
+          },
+          "W_flops": 137596000,
+          "Q_bytes": 103096576,
+          "ai": 1.3,
+          "SOL_time_ms": {
+            "XPU-A": 19.45,
+            "H20": 25.77
+          },
+          "prod_us": {
+            "XPU-A": 100.0
+          }
+        }
+      }
+    },
+    {
+      "name": "l2_norm",
+      "id": "atrex_015",
+      "dtype": "bf16",
+      "framework": "vllm",
+      "symbol": "l2norm_fwd",
+      "module": "vllm.model_executor.layers.fla.ops.l2norm",
+      "phase": "prefill/decode",
+      "shapes": 13,
+      "importance": 0.004661,
+      "roofline": {
+        "median_ai": 0.8,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 6144,
+          "Q_bytes": 8192,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=1 hidden=2048"
+        },
+        "1": {
+          "W_flops": 786432,
+          "Q_bytes": 1048576,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.2,
+            "H20": 0.26
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=128 hidden=2048"
+        },
+        "2": {
+          "W_flops": 1572864,
+          "Q_bytes": 2097152,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.4,
+            "H20": 0.52
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=256 hidden=2048"
+        },
+        "3": {
+          "W_flops": 2949120,
+          "Q_bytes": 3932160,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.74,
+            "H20": 0.98
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=480 hidden=2048"
+        },
+        "4": {
+          "W_flops": 14155776,
+          "Q_bytes": 18874368,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 3.56,
+            "H20": 4.72
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=2304 hidden=2048"
+        },
+        "5": {
+          "W_flops": 24969216,
+          "Q_bytes": 33292288,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 6.28,
+            "H20": 8.32
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=4064 hidden=2048"
+        },
+        "6": {
+          "W_flops": 53673984,
+          "Q_bytes": 71565312,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 13.5,
+            "H20": 17.89
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=8736 hidden=2048"
+        },
+        "7": {
+          "W_flops": 102039552,
+          "Q_bytes": 136052736,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 25.67,
+            "H20": 34.01
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=16608 hidden=2048"
+        },
+        "8": {
+          "W_flops": 150405120,
+          "Q_bytes": 200540160,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 37.84,
+            "H20": 50.14
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=24480 hidden=2048"
+        },
+        "9": {
+          "W_flops": 299237376,
+          "Q_bytes": 398983168,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 75.28,
+            "H20": 99.75
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=48704 hidden=2048"
+        },
+        "10": {
+          "W_flops": 404226048,
+          "Q_bytes": 538968064,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 101.69,
+            "H20": 134.74
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=65792 hidden=2048"
+        },
+        "11": {
+          "W_flops": 607518720,
+          "Q_bytes": 810024960,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 152.83,
+            "H20": 202.51
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=98880 hidden=2048"
+        },
+        "12": {
+          "W_flops": 805306368,
+          "Q_bytes": 1073741824,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 202.59,
+            "H20": 268.44
+          },
+          "description": "(vLLM TP1), L2 norm, tokens=131072 hidden=2048"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 13,
+          "median_us": 59.0,
+          "min_us": 7.6,
+          "max_us": 853.1,
+          "framework": "rtp"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 7.6,
+          "1": 7.7,
+          "2": 7.9,
+          "3": 9.0,
+          "4": 21.5,
+          "5": 30.0,
+          "6": 59.0,
+          "7": 117.2,
+          "8": 173.3,
+          "9": 315.9,
+          "10": 430.0,
+          "11": 635.0,
+          "12": 853.1
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self, hidden_size: int, eps: float=1e-06) -> None:\n        super().__init__()\n        self.hidden_size = hidden_size\n        self.eps = eps\n\n    def forward(self, x: torch.Tensor) -> torch.Tensor:\n        x_float = x.float()\n        norm_sq = (x_float * x_float).sum(dim=-1, keepdim=True)\n        return (x_float * torch.rsqrt(norm_sq + self.eps)).to(x.dtype)\n",
+      "input_code": "import torch\n\ndef _make_inputs(num_tokens: int, hidden_size: int, dtype: str='bfloat16') -> dict[str, torch.Tensor]:\n    dt = getattr(torch, dtype)\n    return {'x': torch.randn(num_tokens, hidden_size, dtype=dt, device='cuda')}\n\ndef get_inputs() -> list[torch.Tensor]:\n    return list(_make_inputs(num_tokens=1024, hidden_size=128).values())\n\ndef get_init_inputs() -> dict[str, object]:\n    return {'hidden_size': 128}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM TP1), L2 norm, tokens=1 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 1,
+            "hidden_size": 2048
+          },
+          "W_flops": 6144,
+          "Q_bytes": 8192,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 7.6
+          }
+        },
+        "1": {
+          "description": "(vLLM TP1), L2 norm, tokens=128 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 128,
+            "hidden_size": 2048
+          },
+          "W_flops": 786432,
+          "Q_bytes": 1048576,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.2,
+            "H20": 0.26
+          },
+          "prod_us": {
+            "XPU-A": 7.7
+          }
+        },
+        "2": {
+          "description": "(vLLM TP1), L2 norm, tokens=256 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 256,
+            "hidden_size": 2048
+          },
+          "W_flops": 1572864,
+          "Q_bytes": 2097152,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.4,
+            "H20": 0.52
+          },
+          "prod_us": {
+            "XPU-A": 7.9
+          }
+        },
+        "3": {
+          "description": "(vLLM TP1), L2 norm, tokens=480 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 480,
+            "hidden_size": 2048
+          },
+          "W_flops": 2949120,
+          "Q_bytes": 3932160,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 0.74,
+            "H20": 0.98
+          },
+          "prod_us": {
+            "XPU-A": 9.0
+          }
+        },
+        "4": {
+          "description": "(vLLM TP1), L2 norm, tokens=2304 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 2304,
+            "hidden_size": 2048
+          },
+          "W_flops": 14155776,
+          "Q_bytes": 18874368,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 3.56,
+            "H20": 4.72
+          },
+          "prod_us": {
+            "XPU-A": 21.5
+          }
+        },
+        "5": {
+          "description": "(vLLM TP1), L2 norm, tokens=4064 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 4064,
+            "hidden_size": 2048
+          },
+          "W_flops": 24969216,
+          "Q_bytes": 33292288,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 6.28,
+            "H20": 8.32
+          },
+          "prod_us": {
+            "XPU-A": 30.0
+          }
+        },
+        "6": {
+          "description": "(vLLM TP1), L2 norm, tokens=8736 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 8736,
+            "hidden_size": 2048
+          },
+          "W_flops": 53673984,
+          "Q_bytes": 71565312,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 13.5,
+            "H20": 17.89
+          },
+          "prod_us": {
+            "XPU-A": 59.0
+          }
+        },
+        "7": {
+          "description": "(vLLM TP1), L2 norm, tokens=16608 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 16608,
+            "hidden_size": 2048
+          },
+          "W_flops": 102039552,
+          "Q_bytes": 136052736,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 25.67,
+            "H20": 34.01
+          },
+          "prod_us": {
+            "XPU-A": 117.2
+          }
+        },
+        "8": {
+          "description": "(vLLM TP1), L2 norm, tokens=24480 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 24480,
+            "hidden_size": 2048
+          },
+          "W_flops": 150405120,
+          "Q_bytes": 200540160,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 37.84,
+            "H20": 50.14
+          },
+          "prod_us": {
+            "XPU-A": 173.3
+          }
+        },
+        "9": {
+          "description": "(vLLM TP1), L2 norm, tokens=48704 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 48704,
+            "hidden_size": 2048
+          },
+          "W_flops": 299237376,
+          "Q_bytes": 398983168,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 75.28,
+            "H20": 99.75
+          },
+          "prod_us": {
+            "XPU-A": 315.9
+          }
+        },
+        "10": {
+          "description": "(vLLM TP1), L2 norm, tokens=65792 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 65792,
+            "hidden_size": 2048
+          },
+          "W_flops": 404226048,
+          "Q_bytes": 538968064,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 101.69,
+            "H20": 134.74
+          },
+          "prod_us": {
+            "XPU-A": 430.0
+          }
+        },
+        "11": {
+          "description": "(vLLM TP1), L2 norm, tokens=98880 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 98880,
+            "hidden_size": 2048
+          },
+          "W_flops": 607518720,
+          "Q_bytes": 810024960,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 152.83,
+            "H20": 202.51
+          },
+          "prod_us": {
+            "XPU-A": 635.0
+          }
+        },
+        "12": {
+          "description": "(vLLM TP1), L2 norm, tokens=131072 hidden=2048",
+          "init_kwargs": {
+            "hidden_size": 2048
+          },
+          "input_kwargs": {
+            "num_tokens": 131072,
+            "hidden_size": 2048
+          },
+          "W_flops": 805306368,
+          "Q_bytes": 1073741824,
+          "ai": 0.8,
+          "SOL_time_ms": {
+            "XPU-A": 202.59,
+            "H20": 268.44
+          },
+          "prod_us": {
+            "XPU-A": 853.1
+          }
+        }
+      }
+    },
+    {
+      "name": "moe_count_and_sort",
+      "id": "atrex_020",
+      "dtype": "int32",
+      "framework": "vllm",
+      "symbol": "moe_count_and_sort_expert_tokens",
+      "module": "vllm::moe::count_and_sort_expert_tokens_kernel via vllm.moe_align_block_size",
+      "phase": "prefill/decode",
+      "shapes": 5,
+      "importance": 0.004544,
+      "roofline": {
+        "median_ai": 0.0,
+        "regime": "indexing/structural",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 0,
+          "Q_bytes": 1092,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(rtp-llm TP1), MoE routing count_and_sort, tokens=1 top_k=8 experts=128"
+        },
+        "1": {
+          "W_flops": 0,
+          "Q_bytes": 5892,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(vLLM TP4), MoE routing count_and_sort, tokens=76 top_k=8 experts=128"
+        },
+        "2": {
+          "W_flops": 0,
+          "Q_bytes": 34308,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "description": "(vLLM TP4), MoE routing count_and_sort, tokens=520 top_k=8 experts=128"
+        },
+        "3": {
+          "W_flops": 0,
+          "Q_bytes": 66244,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.02
+          },
+          "description": "(vLLM TP4), MoE routing count_and_sort, tokens=1019 top_k=8 experts=128"
+        },
+        "4": {
+          "W_flops": 0,
+          "Q_bytes": 131844,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.02,
+            "H20": 0.03
+          },
+          "description": "(vLLM TP4), MoE routing count_and_sort, tokens=2044 top_k=8 experts=128"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 5,
+          "median_us": 16.6,
+          "min_us": 12.7,
+          "max_us": 21.2,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 12.8,
+          "1": 12.7,
+          "2": 16.6,
+          "3": 18.8,
+          "4": 21.2
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self, num_experts: int=128, block_size: int=128) -> None:\n        super().__init__()\n        self.num_experts = int(num_experts)\n        self.block_size = int(block_size)\n\n    def forward(self, topk_ids: torch.Tensor) -> dict[str, torch.Tensor]:\n        flat_ids = topk_ids.flatten()\n        counts = torch.bincount(flat_ids.to(torch.long), minlength=self.num_experts)[:self.num_experts].to(torch.int32)\n        cumsum = torch.empty(self.num_experts + 1, dtype=torch.int32, device=topk_ids.device)\n        cumsum[0] = 0\n        cumsum[1:] = torch.cumsum(counts, dim=0)\n        sorted_chunks = []\n        for expert in range(self.num_experts):\n            token_ids = torch.nonzero(flat_ids == expert, as_tuple=False).flatten().to(torch.int32)\n            if token_ids.numel():\n                sorted_chunks.append(token_ids)\n        if sorted_chunks:\n            sorted_token_ids = torch.cat(sorted_chunks)\n        else:\n            sorted_token_ids = torch.empty((0,), dtype=torch.int32, device=topk_ids.device)\n        return {'sorted_token_ids': sorted_token_ids, 'expert_token_counts': counts, 'cumsum': cumsum}\n",
+      "input_code": "import torch\n\ndef _make_inputs(token_count: int, top_k: int, num_experts: int) -> dict[str, torch.Tensor]:\n    topk_ids = torch.randint(0, int(num_experts), (int(token_count), int(top_k)), dtype=torch.int32, device='cuda')\n    return {'topk_ids': topk_ids}\n",
+      "shape_details": {
+        "0": {
+          "description": "(rtp-llm TP1), MoE routing count_and_sort, tokens=1 top_k=8 experts=128",
+          "init_kwargs": {
+            "num_experts": 128,
+            "block_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 1,
+            "top_k": 8,
+            "num_experts": 128
+          },
+          "W_flops": 0,
+          "Q_bytes": 1092,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 12.8
+          }
+        },
+        "1": {
+          "description": "(vLLM TP4), MoE routing count_and_sort, tokens=76 top_k=8 experts=128",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 76,
+            "num_experts": 128,
+            "top_k": 8
+          },
+          "W_flops": 0,
+          "Q_bytes": 5892,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 12.7
+          }
+        },
+        "2": {
+          "description": "(vLLM TP4), MoE routing count_and_sort, tokens=520 top_k=8 experts=128",
+          "init_kwargs": {
+            "num_experts": 128,
+            "block_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 520,
+            "top_k": 8,
+            "num_experts": 128
+          },
+          "W_flops": 0,
+          "Q_bytes": 34308,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 16.6
+          }
+        },
+        "3": {
+          "description": "(vLLM TP4), MoE routing count_and_sort, tokens=1019 top_k=8 experts=128",
+          "init_kwargs": {
+            "num_experts": 128,
+            "block_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 1019,
+            "top_k": 8,
+            "num_experts": 128
+          },
+          "W_flops": 0,
+          "Q_bytes": 66244,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.02
+          },
+          "prod_us": {
+            "XPU-A": 18.8
+          }
+        },
+        "4": {
+          "description": "(vLLM TP4), MoE routing count_and_sort, tokens=2044 top_k=8 experts=128",
+          "init_kwargs": {
+            "num_experts": 128,
+            "block_size": 128
+          },
+          "input_kwargs": {
+            "token_count": 2044,
+            "top_k": 8,
+            "num_experts": 128
+          },
+          "W_flops": 0,
+          "Q_bytes": 131844,
+          "ai": 0.0,
+          "SOL_time_ms": {
+            "XPU-A": 0.02,
+            "H20": 0.03
+          },
+          "prod_us": {
+            "XPU-A": 21.2
+          }
+        }
+      }
+    },
+    {
+      "name": "fused_rmsnorm_quant",
+      "id": "atrex_012",
+      "dtype": "fp8_e4m3",
+      "framework": "aiter",
+      "symbol": "rmsnorm2d_fwd_with_add_dynamicquant",
+      "module": "aiter.ops.rmsnorm",
+      "phase": "prefill/decode",
+      "shapes": 11,
+      "importance": 0.003433,
+      "roofline": {
+        "median_ai": 0.7,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 1198314,
+          "Q_bytes": 1681876,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.32,
+            "H20": 0.42
+          },
+          "description": "(sglang TP1), fused RMSNorm + FP8 quant, input=(117,2048)"
+        },
+        "1": {
+          "W_flops": 8572554,
+          "Q_bytes": 12006676,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 2.27,
+            "H20": 3.0
+          },
+          "description": "(sglang TP1), fused RMSNorm + FP8 quant, input=(837,2048)"
+        },
+        "2": {
+          "W_flops": 18118098,
+          "Q_bytes": 25371556,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 4.79,
+            "H20": 6.34
+          },
+          "description": "(sglang TP1), fused RMSNorm + FP8 quant, input=(1769,2048)"
+        },
+        "3": {
+          "W_flops": 33388920,
+          "Q_bytes": 46752496,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 8.82,
+            "H20": 11.69
+          },
+          "description": "(SGLang TP1), fused RMSNorm + FP8 quant, input=(3260,2048)"
+        },
+        "4": {
+          "W_flops": 116748558,
+          "Q_bytes": 163465756,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 30.84,
+            "H20": 40.87
+          },
+          "description": "(SGLang TP1), fused RMSNorm + FP8 quant, input=(11399,2048)"
+        },
+        "5": {
+          "W_flops": 267111360,
+          "Q_bytes": 373991296,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 70.56,
+            "H20": 93.5
+          },
+          "description": "(SGLang TP1), fused RMSNorm + FP8 quant, input=(26080,2048)"
+        },
+        "6": {
+          "W_flops": 13313300,
+          "Q_bytes": 18647592,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.52,
+            "H20": 4.66
+          },
+          "description": "(SGLang TP8), fused RMSNorm + FP8 quant, input=(650,4096)"
+        },
+        "7": {
+          "W_flops": 20748266,
+          "Q_bytes": 29056980,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 5.48,
+            "H20": 7.26
+          },
+          "description": "(SGLang TP8), fused RMSNorm + FP8 quant, input=(1013,4096)"
+        },
+        "8": {
+          "W_flops": 42151956,
+          "Q_bytes": 59023400,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 11.14,
+            "H20": 14.76
+          },
+          "description": "(SGLang TP8), fused RMSNorm + FP8 quant, input=(2058,4096)"
+        },
+        "9": {
+          "W_flops": 83628006,
+          "Q_bytes": 117092300,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 22.09,
+            "H20": 29.27
+          },
+          "description": "(SGLang TP8), fused RMSNorm + FP8 quant, input=(4083,4096)"
+        },
+        "10": {
+          "W_flops": 168116256,
+          "Q_bytes": 235380800,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 44.41,
+            "H20": 58.85
+          },
+          "description": "(SGLang TP8), fused RMSNorm + FP8 quant, input=(8208,4096)"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 11,
+          "median_us": 23.4,
+          "min_us": 7.9,
+          "max_us": 140.9,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 7.9,
+          "1": 11.1,
+          "2": 15.9,
+          "3": 23.4,
+          "4": 65.1,
+          "5": 140.9,
+          "6": 13.5,
+          "7": 16.6,
+          "8": 27.4,
+          "9": 47.0,
+          "10": 86.5
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self, eps: float=1e-05) -> None:\n        super().__init__()\n        self.eps = eps\n\n    def forward(self, x: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:\n        residual_out = x + residual\n        normed = F.rms_norm(residual_out, (residual_out.shape[-1],), weight, self.eps)\n        normed_f = normed.to(torch.float32)\n        finfo = torch.finfo(torch.float8_e4m3fnuz)\n        amax = normed_f.abs().amax(dim=-1, keepdim=True)\n        scale = amax / finfo.max\n        scale = torch.where(scale == 0, torch.ones_like(scale), scale)\n        quantized = (normed_f / scale).to(torch.float8_e4m3fnuz)\n        return (quantized, scale.to(torch.float32), residual_out)\n",
+      "input_code": "import torch\n\n\ndef _make_inputs(token_count: int, hidden_size: int) -> dict[str, torch.Tensor]:\n    x = torch.randn(token_count, hidden_size, dtype=torch.bfloat16, device='cuda')\n    residual = torch.randn(token_count, hidden_size, dtype=torch.bfloat16, device='cuda')\n    weight = torch.randn(hidden_size, dtype=torch.bfloat16, device='cuda')\n    return {'x': x, 'residual': residual, 'weight': weight}\n",
+      "shape_details": {
+        "0": {
+          "description": "(sglang TP1), fused RMSNorm + FP8 quant, input=(117,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 117,
+            "hidden_size": 2048
+          },
+          "W_flops": 1198314,
+          "Q_bytes": 1681876,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.32,
+            "H20": 0.42
+          },
+          "prod_us": {
+            "XPU-A": 7.9
+          }
+        },
+        "1": {
+          "description": "(sglang TP1), fused RMSNorm + FP8 quant, input=(837,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 837,
+            "hidden_size": 2048
+          },
+          "W_flops": 8572554,
+          "Q_bytes": 12006676,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 2.27,
+            "H20": 3.0
+          },
+          "prod_us": {
+            "XPU-A": 11.1
+          }
+        },
+        "2": {
+          "description": "(sglang TP1), fused RMSNorm + FP8 quant, input=(1769,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 1769,
+            "hidden_size": 2048
+          },
+          "W_flops": 18118098,
+          "Q_bytes": 25371556,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 4.79,
+            "H20": 6.34
+          },
+          "prod_us": {
+            "XPU-A": 15.9
+          }
+        },
+        "3": {
+          "description": "(SGLang TP1), fused RMSNorm + FP8 quant, input=(3260,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 3260,
+            "hidden_size": 2048
+          },
+          "W_flops": 33388920,
+          "Q_bytes": 46752496,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 8.82,
+            "H20": 11.69
+          },
+          "prod_us": {
+            "XPU-A": 23.4
+          }
+        },
+        "4": {
+          "description": "(SGLang TP1), fused RMSNorm + FP8 quant, input=(11399,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 11399,
+            "hidden_size": 2048
+          },
+          "W_flops": 116748558,
+          "Q_bytes": 163465756,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 30.84,
+            "H20": 40.87
+          },
+          "prod_us": {
+            "XPU-A": 65.1
+          }
+        },
+        "5": {
+          "description": "(SGLang TP1), fused RMSNorm + FP8 quant, input=(26080,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 26080,
+            "hidden_size": 2048
+          },
+          "W_flops": 267111360,
+          "Q_bytes": 373991296,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 70.56,
+            "H20": 93.5
+          },
+          "prod_us": {
+            "XPU-A": 140.9
+          }
+        },
+        "6": {
+          "description": "(SGLang TP8), fused RMSNorm + FP8 quant, input=(650,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 650,
+            "hidden_size": 4096
+          },
+          "W_flops": 13313300,
+          "Q_bytes": 18647592,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.52,
+            "H20": 4.66
+          },
+          "prod_us": {
+            "XPU-A": 13.5
+          }
+        },
+        "7": {
+          "description": "(SGLang TP8), fused RMSNorm + FP8 quant, input=(1013,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 1013,
+            "hidden_size": 4096
+          },
+          "W_flops": 20748266,
+          "Q_bytes": 29056980,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 5.48,
+            "H20": 7.26
+          },
+          "prod_us": {
+            "XPU-A": 16.6
+          }
+        },
+        "8": {
+          "description": "(SGLang TP8), fused RMSNorm + FP8 quant, input=(2058,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 2058,
+            "hidden_size": 4096
+          },
+          "W_flops": 42151956,
+          "Q_bytes": 59023400,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 11.14,
+            "H20": 14.76
+          },
+          "prod_us": {
+            "XPU-A": 27.4
+          }
+        },
+        "9": {
+          "description": "(SGLang TP8), fused RMSNorm + FP8 quant, input=(4083,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 4083,
+            "hidden_size": 4096
+          },
+          "W_flops": 83628006,
+          "Q_bytes": 117092300,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 22.09,
+            "H20": 29.27
+          },
+          "prod_us": {
+            "XPU-A": 47.0
+          }
+        },
+        "10": {
+          "description": "(SGLang TP8), fused RMSNorm + FP8 quant, input=(8208,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "token_count": 8208,
+            "hidden_size": 4096
+          },
+          "W_flops": 168116256,
+          "Q_bytes": 235380800,
+          "ai": 0.7,
+          "SOL_time_ms": {
+            "XPU-A": 44.41,
+            "H20": 58.85
+          },
+          "prod_us": {
+            "XPU-A": 86.5
+          }
+        }
+      }
+    },
+    {
+      "name": "moe_sum_reduce",
+      "id": "atrex_021",
+      "dtype": "bf16",
+      "framework": "sglang",
+      "symbol": "moe_sum_reduce_triton",
+      "module": "sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe_triton_kernels",
+      "phase": "prefill/decode",
+      "shapes": 7,
+      "importance": 0.003393,
+      "roofline": {
+        "median_ai": 0.4,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 180666368,
+          "Q_bytes": 406499328,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 76.7,
+            "H20": 101.62
+          },
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=11027 hidden=2048"
+        },
+        "1": {
+          "W_flops": 98795520,
+          "Q_bytes": 222289920,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 41.94,
+            "H20": 55.57
+          },
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=6030 hidden=2048"
+        },
+        "2": {
+          "W_flops": 98025472,
+          "Q_bytes": 220557312,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 41.61,
+            "H20": 55.14
+          },
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=5983 hidden=2048"
+        },
+        "3": {
+          "W_flops": 82624512,
+          "Q_bytes": 185905152,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 35.08,
+            "H20": 46.48
+          },
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=5043 hidden=2048"
+        },
+        "4": {
+          "W_flops": 81854464,
+          "Q_bytes": 184172544,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 34.75,
+            "H20": 46.04
+          },
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=4996 hidden=2048"
+        },
+        "5": {
+          "W_flops": 71483392,
+          "Q_bytes": 160837632,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 30.35,
+            "H20": 40.21
+          },
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=4363 hidden=2048"
+        },
+        "6": {
+          "W_flops": 68730880,
+          "Q_bytes": 154644480,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 29.18,
+            "H20": 38.66
+          },
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=4195 hidden=2048"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 7,
+          "median_us": 179.8,
+          "min_us": 154.0,
+          "max_us": 362.4,
+          "framework": "sglang"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 362.4,
+          "1": 209.8,
+          "2": 213.3,
+          "3": 179.8,
+          "4": 178.4,
+          "5": 159.2,
+          "6": 154.0
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\n\nclass Model(nn.Module):\n\n    def __init__(self, routed_scaling_factor: float=1.0) -> None:\n        super().__init__()\n        self.routed_scaling_factor = float(routed_scaling_factor)\n\n    def forward(self, expert_outputs: torch.Tensor) -> torch.Tensor:\n        out = expert_outputs.float().sum(dim=1) * self.routed_scaling_factor\n        return out.to(expert_outputs.dtype)\n",
+      "input_code": "import torch\n\ndef _make_inputs(token_count: int, top_k: int, hidden_size: int) -> dict[str, torch.Tensor]:\n    expert_outputs = torch.randn(token_count, top_k, hidden_size, dtype=torch.bfloat16, device='cuda') * 0.02\n    return {'expert_outputs': expert_outputs}\n",
+      "shape_details": {
+        "0": {
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=11027 hidden=2048",
+          "init_kwargs": {
+            "routed_scaling_factor": 1.0
+          },
+          "input_kwargs": {
+            "token_count": 11027,
+            "top_k": 8,
+            "hidden_size": 2048
+          },
+          "W_flops": 180666368,
+          "Q_bytes": 406499328,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 76.7,
+            "H20": 101.62
+          },
+          "prod_us": {
+            "XPU-A": 362.4
+          }
+        },
+        "1": {
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=6030 hidden=2048",
+          "init_kwargs": {
+            "routed_scaling_factor": 1.0
+          },
+          "input_kwargs": {
+            "token_count": 6030,
+            "top_k": 8,
+            "hidden_size": 2048
+          },
+          "W_flops": 98795520,
+          "Q_bytes": 222289920,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 41.94,
+            "H20": 55.57
+          },
+          "prod_us": {
+            "XPU-A": 209.8
+          }
+        },
+        "2": {
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=5983 hidden=2048",
+          "init_kwargs": {
+            "routed_scaling_factor": 1.0
+          },
+          "input_kwargs": {
+            "token_count": 5983,
+            "top_k": 8,
+            "hidden_size": 2048
+          },
+          "W_flops": 98025472,
+          "Q_bytes": 220557312,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 41.61,
+            "H20": 55.14
+          },
+          "prod_us": {
+            "XPU-A": 213.3
+          }
+        },
+        "3": {
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=5043 hidden=2048",
+          "init_kwargs": {
+            "routed_scaling_factor": 1.0
+          },
+          "input_kwargs": {
+            "token_count": 5043,
+            "top_k": 8,
+            "hidden_size": 2048
+          },
+          "W_flops": 82624512,
+          "Q_bytes": 185905152,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 35.08,
+            "H20": 46.48
+          },
+          "prod_us": {
+            "XPU-A": 179.8
+          }
+        },
+        "4": {
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=4996 hidden=2048",
+          "init_kwargs": {
+            "routed_scaling_factor": 1.0
+          },
+          "input_kwargs": {
+            "token_count": 4996,
+            "top_k": 8,
+            "hidden_size": 2048
+          },
+          "W_flops": 81854464,
+          "Q_bytes": 184172544,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 34.75,
+            "H20": 46.04
+          },
+          "prod_us": {
+            "XPU-A": 178.4
+          }
+        },
+        "5": {
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=4363 hidden=2048",
+          "init_kwargs": {
+            "routed_scaling_factor": 1.0
+          },
+          "input_kwargs": {
+            "token_count": 4363,
+            "top_k": 8,
+            "hidden_size": 2048
+          },
+          "W_flops": 71483392,
+          "Q_bytes": 160837632,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 30.35,
+            "H20": 40.21
+          },
+          "prod_us": {
+            "XPU-A": 159.2
+          }
+        },
+        "6": {
+          "description": "(SGLang TP inferred), MoE top-8 expert sum, tokens=4195 hidden=2048",
+          "init_kwargs": {
+            "routed_scaling_factor": 1.0
+          },
+          "input_kwargs": {
+            "token_count": 4195,
+            "top_k": 8,
+            "hidden_size": 2048
+          },
+          "W_flops": 68730880,
+          "Q_bytes": 154644480,
+          "ai": 0.4,
+          "SOL_time_ms": {
+            "XPU-A": 29.18,
+            "H20": 38.66
+          },
+          "prod_us": {
+            "XPU-A": 154.0
+          }
+        }
+      }
+    },
+    {
+      "name": "layer_norm",
+      "id": "atrex_016",
+      "dtype": "bf16",
+      "framework": "vllm",
+      "symbol": "layer_norm",
+      "module": "vllm",
+      "phase": "prefill/decode",
+      "shapes": 13,
+      "importance": 0.000773,
+      "roofline": {
+        "median_ai": 1.7,
+        "regime": "memory-bound",
+        "hardware_targets": [
+          "H20",
+          "XPU-A"
+        ]
+      },
+      "roofline_shapes": {
+        "0": {
+          "W_flops": 2225664,
+          "Q_bytes": 1276416,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.24,
+            "H20": 0.32
+          },
+          "description": "(vLLM TP4), shape=(276,1,1152)"
+        },
+        "1": {
+          "W_flops": 4838400,
+          "Q_bytes": 2769408,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.52,
+            "H20": 0.69
+          },
+          "description": "(vLLM TP4), shape=(600,1,1152)"
+        },
+        "2": {
+          "W_flops": 8160768,
+          "Q_bytes": 4667904,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.88,
+            "H20": 1.17
+          },
+          "description": "(vLLM TP4), shape=(1012,1,1152)"
+        },
+        "3": {
+          "W_flops": 16321536,
+          "Q_bytes": 9331200,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 1.76,
+            "H20": 2.33
+          },
+          "description": "(vLLM TP4), shape=(2024,1,1152)"
+        },
+        "4": {
+          "W_flops": 33062400,
+          "Q_bytes": 18897408,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.57,
+            "H20": 4.72
+          },
+          "description": "(vLLM TP4), shape=(4100,1,1152)"
+        },
+        "5": {
+          "W_flops": 65995776,
+          "Q_bytes": 37716480,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 7.12,
+            "H20": 9.43
+          },
+          "description": "(vLLM TP4), shape=(8184,1,1152)"
+        },
+        "6": {
+          "W_flops": 124798464,
+          "Q_bytes": 71318016,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 13.46,
+            "H20": 17.83
+          },
+          "description": "(vLLM TP4), shape=(15476,1,1152)"
+        },
+        "7": {
+          "W_flops": 201212928,
+          "Q_bytes": 114983424,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 21.69,
+            "H20": 28.75
+          },
+          "description": "(vLLM TP4), shape=(24952,1,1152)"
+        },
+        "8": {
+          "W_flops": 327075840,
+          "Q_bytes": 186905088,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 35.27,
+            "H20": 46.73
+          },
+          "description": "(vLLM TP4), shape=(40560,1,1152)"
+        },
+        "9": {
+          "W_flops": 1307328512,
+          "Q_bytes": 747053056,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 140.95,
+            "H20": 186.76
+          },
+          "description": "(SGLang TP1), LayerNorm, tokens=91192 hidden=2048"
+        },
+        "10": {
+          "W_flops": 14336,
+          "Q_bytes": 16384,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "description": "(rtp-llm TP1), shape=(1,2048)"
+        },
+        "11": {
+          "W_flops": 28672,
+          "Q_bytes": 32768,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP1), shape=(1,4096)"
+        },
+        "12": {
+          "W_flops": 35840,
+          "Q_bytes": 40960,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "description": "(rtp-llm TP1), shape=(1,5120)"
+        }
+      },
+      "production_perf": {
+        "XPU-A": {
+          "shapes_measured": 13,
+          "median_us": 15.8,
+          "min_us": 7.6,
+          "max_us": 788.4,
+          "framework": "aiter"
+        }
+      },
+      "production_shapes": {
+        "XPU-A": {
+          "0": 8.9,
+          "1": 9.9,
+          "2": 12.1,
+          "3": 15.8,
+          "4": 23.3,
+          "5": 38.0,
+          "6": 64.0,
+          "7": 97.5,
+          "8": 152.2,
+          "9": 788.4,
+          "10": 7.6,
+          "11": 8.1,
+          "12": 8.9
+        }
+      },
+      "reference_code": "import torch\nimport torch.nn as nn\nimport torch.nn.functional as F\n\nclass Model(nn.Module):\n\n    def __init__(self) -> None:\n        super().__init__()\n\n    def forward(self, x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor) -> torch.Tensor:\n        if x.ndim == 0:\n            return x.clone()\n        return F.layer_norm(x.float(), (x.shape[-1],), weight=weight.float(), bias=bias.float()).to(x.dtype)\n",
+      "input_code": "import torch\n\ndef _make_inputs(shape: list[int]) -> dict[str, torch.Tensor]:\n    tensor_shape = tuple((int(dim) for dim in shape))\n    if len(tensor_shape) == 0:\n        tensor_shape = (1,)\n    x = torch.randn(tensor_shape, dtype=torch.bfloat16, device='cuda')\n    feature_dim = tensor_shape[-1]\n    weight = torch.randn(feature_dim, dtype=torch.bfloat16, device='cuda')\n    bias = torch.randn(feature_dim, dtype=torch.bfloat16, device='cuda')\n    return {'x': x, 'weight': weight, 'bias': bias}\n",
+      "shape_details": {
+        "0": {
+          "description": "(vLLM TP4), shape=(276,1,1152)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              276,
+              1,
+              1152
+            ]
+          },
+          "W_flops": 2225664,
+          "Q_bytes": 1276416,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.24,
+            "H20": 0.32
+          },
+          "prod_us": {
+            "XPU-A": 8.9
+          }
+        },
+        "1": {
+          "description": "(vLLM TP4), shape=(600,1,1152)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              600,
+              1,
+              1152
+            ]
+          },
+          "W_flops": 4838400,
+          "Q_bytes": 2769408,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.52,
+            "H20": 0.69
+          },
+          "prod_us": {
+            "XPU-A": 9.9
+          }
+        },
+        "2": {
+          "description": "(vLLM TP4), shape=(1012,1,1152)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1012,
+              1,
+              1152
+            ]
+          },
+          "W_flops": 8160768,
+          "Q_bytes": 4667904,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 0.88,
+            "H20": 1.17
+          },
+          "prod_us": {
+            "XPU-A": 12.1
+          }
+        },
+        "3": {
+          "description": "(vLLM TP4), shape=(2024,1,1152)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              2024,
+              1,
+              1152
+            ]
+          },
+          "W_flops": 16321536,
+          "Q_bytes": 9331200,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 1.76,
+            "H20": 2.33
+          },
+          "prod_us": {
+            "XPU-A": 15.8
+          }
+        },
+        "4": {
+          "description": "(vLLM TP4), shape=(4100,1,1152)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              4100,
+              1,
+              1152
+            ]
+          },
+          "W_flops": 33062400,
+          "Q_bytes": 18897408,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 3.57,
+            "H20": 4.72
+          },
+          "prod_us": {
+            "XPU-A": 23.3
+          }
+        },
+        "5": {
+          "description": "(vLLM TP4), shape=(8184,1,1152)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              8184,
+              1,
+              1152
+            ]
+          },
+          "W_flops": 65995776,
+          "Q_bytes": 37716480,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 7.12,
+            "H20": 9.43
+          },
+          "prod_us": {
+            "XPU-A": 38.0
+          }
+        },
+        "6": {
+          "description": "(vLLM TP4), shape=(15476,1,1152)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              15476,
+              1,
+              1152
+            ]
+          },
+          "W_flops": 124798464,
+          "Q_bytes": 71318016,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 13.46,
+            "H20": 17.83
+          },
+          "prod_us": {
+            "XPU-A": 64.0
+          }
+        },
+        "7": {
+          "description": "(vLLM TP4), shape=(24952,1,1152)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              24952,
+              1,
+              1152
+            ]
+          },
+          "W_flops": 201212928,
+          "Q_bytes": 114983424,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 21.69,
+            "H20": 28.75
+          },
+          "prod_us": {
+            "XPU-A": 97.5
+          }
+        },
+        "8": {
+          "description": "(vLLM TP4), shape=(40560,1,1152)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              40560,
+              1,
+              1152
+            ]
+          },
+          "W_flops": 327075840,
+          "Q_bytes": 186905088,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 35.27,
+            "H20": 46.73
+          },
+          "prod_us": {
+            "XPU-A": 152.2
+          }
+        },
+        "9": {
+          "description": "(SGLang TP1), LayerNorm, tokens=91192 hidden=2048",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              91192,
+              2048
+            ]
+          },
+          "W_flops": 1307328512,
+          "Q_bytes": 747053056,
+          "ai": 1.7,
+          "SOL_time_ms": {
+            "XPU-A": 140.95,
+            "H20": 186.76
+          },
+          "prod_us": {
+            "XPU-A": 788.4
+          }
+        },
+        "10": {
+          "description": "(rtp-llm TP1), shape=(1,2048)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1,
+              2048
+            ]
+          },
+          "W_flops": 14336,
+          "Q_bytes": 16384,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.0,
+            "H20": 0.0
+          },
+          "prod_us": {
+            "XPU-A": 7.6
+          }
+        },
+        "11": {
+          "description": "(rtp-llm TP1), shape=(1,4096)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1,
+              4096
+            ]
+          },
+          "W_flops": 28672,
+          "Q_bytes": 32768,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 8.1
+          }
+        },
+        "12": {
+          "description": "(rtp-llm TP1), shape=(1,5120)",
+          "init_kwargs": null,
+          "input_kwargs": {
+            "shape": [
+              1,
+              5120
+            ]
+          },
+          "W_flops": 35840,
+          "Q_bytes": 40960,
+          "ai": 0.9,
+          "SOL_time_ms": {
+            "XPU-A": 0.01,
+            "H20": 0.01
+          },
+          "prod_us": {
+            "XPU-A": 8.9
+          }
+        }
+      }
+    }
+  ]
+}

--- a/site/src/pages/operator/[id].astro
+++ b/site/src/pages/operator/[id].astro
@@ -1,0 +1,261 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import operatorData from '../../data/operators.json';
+import { createHighlighter } from 'shiki';
+
+const highlighter = await createHighlighter({
+  themes: ['github-dark-dimmed'],
+  langs: ['python'],
+});
+
+function highlight(code: string): string {
+  if (!code.trim()) return '';
+  return highlighter.codeToHtml(code.replace(/\n$/, ''), {
+    lang: 'python',
+    theme: 'github-dark-dimmed',
+  });
+}
+
+export function getStaticPaths() {
+  const { operators } = operatorData as any;
+  return operators.map((op: any) => ({
+    params: { id: op.id },
+    props: { op },
+  }));
+}
+
+const { op } = Astro.props as { op: any };
+const { hardware, hardware_specs } = operatorData as any;
+
+const hwShort: Record<string, string> = {
+  'XPU-A': 'XPU-A',
+  'H20': 'H20',
+};
+
+const defaultHw = 'XPU-A';
+const details = op.shape_details || {};
+const shapeIds = Object.keys(details).sort((a, b) => parseInt(a) - parseInt(b));
+const hwList = hardware as string[];
+const hwLabels = hwList.map((hw: string) => hwShort[hw] || hw);
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+function dtypeBadge(dtype: string) {
+  if (dtype === 'bf16') return 'badge-bf16';
+  if (dtype === 'fp16') return 'badge-fp16';
+  if (dtype.startsWith('fp8')) return 'badge-fp8';
+  if (dtype === 'fp32') return 'badge-fp32';
+  return 'badge-int32';
+}
+
+function fmtTime(us: number | null | undefined): string {
+  if (us == null) return '—';
+  return us >= 1000 ? (us / 1000).toFixed(2) + ' ms' : us.toFixed(2) + ' us';
+}
+
+function getProdUs(sid: string): number | null {
+  const prodMap = details[sid]?.prod_us;
+  if (!prodMap || typeof prodMap !== 'object') return null;
+  for (const sku of hwList) {
+    if (prodMap[sku] != null) return prodMap[sku];
+  }
+  return null;
+}
+
+function fmtS(sol: number | null | undefined, prod: number | null | undefined): string {
+  if (sol == null || prod == null || prod === 0) return '—';
+  return ((sol / prod) * 100).toFixed(1) + '%';
+}
+
+function sClass(sol: number | null | undefined, prod: number | null | undefined): string {
+  if (sol == null || prod == null || prod === 0) return 'text-gray-600';
+  const s = sol / prod;
+  if (s >= 1.0) return 'text-white font-semibold';
+  if (s >= 0.33) return 'text-emerald-400';
+  if (s >= 0.125) return 'text-amber-400';
+  return 'text-red-400';
+}
+
+function fmtVal(v: any): string {
+  if (v == null) return '—';
+  if (Array.isArray(v)) {
+    if (v.length === 0) return '[]';
+    const uniq = [...new Set(v)];
+    if (uniq.length === 1) return `[${uniq[0]}] × ${v.length}`;
+    if (v.length > 8) return `[${v.slice(0, 4).join(', ')}, …] (${v.length})`;
+    return `[${v.join(', ')}]`;
+  }
+  return String(v);
+}
+
+const kwargKeys: string[] = [];
+if (shapeIds.length > 0) {
+  const ik = details[shapeIds[0]]?.input_kwargs || {};
+  for (const k of Object.keys(ik)) {
+    kwargKeys.push(k);
+  }
+}
+
+const refHtml = op.reference_code ? highlight(op.reference_code) : '';
+const inputHtml = op.input_code ? highlight(op.input_code) : '';
+const importanceStr = (op.importance * 100).toFixed(1) + '%';
+---
+
+<Layout title={`${op.name} — Atrex-Bench`}>
+  <div class="page-container pt-10 pb-20">
+
+    <!-- Breadcrumb -->
+    <nav class="mb-8">
+      <a href={`${base}/data`} class="text-gray-500 hover:text-white text-sm transition-colors">
+        &larr; Data
+      </a>
+    </nav>
+
+    <!-- Header -->
+    <div class="mb-10">
+      <div class="flex items-baseline gap-3 mb-2">
+        <span class="text-gray-500 font-mono text-sm">#{op.id.replace('atrex_', '')}</span>
+        <h1 class="page-title">{op.name}</h1>
+      </div>
+      <div class="flex flex-wrap items-center gap-2 text-xs mt-3">
+        <span class={`badge ${dtypeBadge(op.dtype)}`}>{op.dtype}</span>
+        <span class="text-gray-600 font-mono">{op.framework}</span>
+        <span class="text-gray-700">&middot;</span>
+        <span class="text-gray-600 font-mono">{op.phase === 'prefill/decode' ? 'both' : (op.phase || '')}</span>
+        <span class="text-gray-700">&middot;</span>
+        <span class="text-gray-600 font-mono">{op.module}</span>
+        <span class="text-gray-700">&middot;</span>
+        <span class="text-gray-500">importance <span class="text-white font-mono">{importanceStr}</span></span>
+      </div>
+    </div>
+
+    <!-- Reference Implementation -->
+    {op.reference_code && (
+      <div class="mb-12">
+        <div class="flex items-baseline justify-between mb-3">
+          <h2 class="section-heading !mt-0 !mb-0">Reference Implementation</h2>
+          <span class="text-gray-600 text-xs font-mono">reference.py</span>
+        </div>
+        <div class="shiki-wrapper" set:html={refHtml} />
+      </div>
+    )}
+
+    <!-- Shapes -->
+    <div class="flex items-baseline justify-between">
+      <h2 class="section-heading">Shapes</h2>
+      <div class="flex items-center gap-2">
+        <span class="text-xs text-gray-500">T<sub>SOL</sub> hardware:</span>
+        <select id="shape-hw-select" class="bg-gray-800 border border-gray-700 rounded px-2 py-1 text-xs text-gray-300 focus:border-brand-600 focus:outline-none">
+          {hwList.map((hw: string, i: number) => (
+            <option value={String(i)} selected={hw === defaultHw}>{hwShort[hw] || hw}</option>
+          ))}
+        </select>
+      </div>
+    </div>
+    <div class="card overflow-hidden p-0 mb-12">
+      <div class="overflow-x-auto">
+        <table class="w-full text-xs font-mono" id="shape-table">
+          <thead>
+            <tr class="border-b border-gray-800 bg-gray-900/50">
+              <th class="text-left py-2.5 px-3 text-gray-400 font-medium">#</th>
+              {kwargKeys.map((k) => (
+                <th class="text-right py-2.5 px-3 text-gray-400 font-medium whitespace-nowrap">{k}</th>
+              ))}
+              <th class="text-right py-2.5 px-3 text-gray-400 font-medium whitespace-nowrap" id="sol-col-header"
+                  set:html={`T<sub>SOL</sub>(${hwShort[defaultHw] || defaultHw})`} />
+              <th class="text-right py-2.5 px-3 text-gray-400 font-medium whitespace-nowrap" set:html={"T<sub>Prod</sub>"} />
+              <th class="text-right py-2.5 px-3 text-gray-400 font-medium whitespace-nowrap">S</th>
+            </tr>
+          </thead>
+          <tbody>
+            {shapeIds.map((sid) => {
+              const prodUs = getProdUs(sid);
+              const solUs = details[sid]?.SOL_time_ms?.[defaultHw];
+              return (
+              <tr class="border-b border-gray-800/30 hover:bg-gray-800/20 transition-colors"
+                  data-sols={JSON.stringify(hwList.map((hw: string) => details[sid]?.SOL_time_ms?.[hw] ?? null))}>
+                <td class="py-2 px-3 text-gray-500">{sid}</td>
+                {kwargKeys.map((k) => (
+                  <td class="py-2 px-3 text-right text-gray-300 whitespace-nowrap">{fmtVal(details[sid]?.input_kwargs?.[k])}</td>
+                ))}
+                <td class="py-2 px-3 text-right text-gray-300 whitespace-nowrap sol-cell">{fmtTime(solUs)}</td>
+                <td class={`py-2 px-3 text-right whitespace-nowrap ${prodUs != null ? 'text-brand-300' : 'text-gray-600'}`}>{fmtTime(prodUs)}</td>
+                <td class={`py-2 px-3 text-right whitespace-nowrap ${sClass(solUs, prodUs)}`}>{fmtS(solUs, prodUs)}</td>
+              </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Input Generation -->
+    {op.input_code && (
+      <div class="mb-12">
+        <div class="flex items-baseline justify-between mb-3">
+          <h2 class="section-heading !mt-0 !mb-0">Input Generation</h2>
+          <span class="text-gray-600 text-xs font-mono">input.py</span>
+        </div>
+        <div class="shiki-wrapper" set:html={inputHtml} />
+      </div>
+    )}
+
+  </div>
+</Layout>
+
+<style>
+  .shiki-wrapper {
+    border: 1px solid rgb(48 54 61);
+    border-radius: 0.75rem;
+    overflow: hidden;
+  }
+  .shiki-wrapper :global(pre.shiki) {
+    margin: 0;
+    padding: 1.25rem 1.5rem;
+    overflow-x: auto;
+    font-size: 0.8rem;
+    line-height: 1.7;
+    border-radius: 0;
+  }
+  .shiki-wrapper :global(code) {
+    counter-reset: line;
+  }
+  .shiki-wrapper :global(code .line) {
+    display: inline;
+  }
+  .shiki-wrapper :global(code .line::before) {
+    counter-increment: line;
+    content: counter(line);
+    display: inline-block;
+    width: 2rem;
+    margin-right: 1.5rem;
+    text-align: right;
+    color: rgb(110 118 129);
+    user-select: none;
+    -webkit-user-select: none;
+  }
+</style>
+
+<script define:vars={{ hwLabels }}>
+  const select = document.getElementById('shape-hw-select');
+  const header = document.getElementById('sol-col-header');
+  const rows = document.querySelectorAll('#shape-table tbody tr');
+
+  function fmtUs(us) {
+    if (us == null) return '—';
+    return us >= 1000 ? (us / 1000).toFixed(2) + ' ms' : us.toFixed(2) + ' us';
+  }
+
+  if (select) {
+    select.addEventListener('change', () => {
+      const idx = parseInt(select.value);
+      const label = hwLabels[idx];
+      header.innerHTML = `T<sub>SOL</sub>(${label})`;
+      rows.forEach(row => {
+        const sols = JSON.parse(row.dataset.sols || '[]');
+        const cell = row.querySelector('.sol-cell');
+        if (cell) cell.textContent = fmtUs(sols[idx]);
+      });
+    });
+  }
+</script>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -14,7 +14,7 @@
 @layer components {
   /* ── Unified layout container ── */
   .page-container {
-    @apply max-w-5xl mx-auto px-6 sm:px-8 lg:px-10;
+    @apply max-w-7xl mx-auto px-4 sm:px-6 lg:px-8;
   }
   .page-section {
     @apply py-14 sm:py-20;
@@ -47,7 +47,7 @@
 
   /* ── Badges ── */
   .badge {
-    @apply inline-block px-2.5 py-0.5 rounded-full text-xs font-medium;
+    @apply inline-block px-1.5 py-px rounded-full text-[10px] leading-4 font-medium;
   }
   .badge-bf16 {
     @apply bg-blue-900/50 text-blue-300 border border-blue-800;


### PR DESCRIPTION
**Add operator detail pages and enhanced data tables**
- Operator detail pages — each operator gets a dedicated page at /operator/{id} with syntax-highlighted reference implementation, per-shape kwargs/SOL/production time table, and a hardware selector dropdown for T_SOL
- Richer data extraction — extract-data.py now emits reference_code, input_code, and merged shape_details (kwargs + roofline + production times) per operator; also plumbs launch_overhead_us from hardware YAML
- Enhanced data tables — all three views (Catalog, Roofline, Shape) gain an ID column, full column sorting with visual indicators, and clickable operator names linking to detail pages
- Launch overhead clamping — SOL times at or below the hardware launch overhead floor display as < {floor} us; S > 100% shows a warning indicator
- Compact styling — wider page container (5xl → 7xl) and denser badge sizing to accommodate richer tables