### PR TITLE
refactor: site config driven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,10 @@ env/
 Thumbs.db
 
 # Environment
-.env
+/.env
+site/.env.local
+site/.env.*
+!site/.env
 
 # Evaluation outputs
 results/

--- a/site/.env
+++ b/site/.env
@@ -1,0 +1,14 @@
+# Atrex-Bench site configuration (defaults)
+# Override in .env.local or use `astro build --mode <name>` to load .env.<name>.
+
+SITE_URL=https://alibaba.github.io
+SITE_BASE=/atrex-bench
+GITHUB_REPO=https://github.com/alibaba/atrex-bench
+DOCKER_IMAGE=<YOUR_REGISTRY>/atrex-bench:rocm7.2
+DEFAULT_HW=XPU-A
+PROD_SKU=XPU-A
+PROD_HARDWARE=["XPU-A","H20"]
+HW_SHORT={"XPU-A":"XPU-A","H20":"H20"}
+
+# Used by extract-data.py (relative to repo root)
+DATA_DIR=data

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,9 +1,15 @@
 import { defineConfig } from 'astro/config';
+import { loadEnv } from 'vite';
 import tailwind from '@astrojs/tailwind';
 
+const mode = process.argv.includes('--mode')
+  ? process.argv[process.argv.indexOf('--mode') + 1]
+  : (process.env.NODE_ENV || 'production');
+const env = loadEnv(mode, process.cwd(), '');
+
 export default defineConfig({
-  site: 'https://alibaba.github.io',
-  base: '/atrex-bench',
+  site: env.SITE_URL || 'https://alibaba.github.io',
+  base: env.SITE_BASE || '/atrex-bench',
   integrations: [tailwind()],
   output: 'static',
 });

--- a/site/scripts/extract-data.py
+++ b/site/scripts/extract-data.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-"""Extract operator data from data/ for the static site."""
+"""Extract operator data for the static site."""
 
 import json
+import os
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
-DATA_DIR = REPO_ROOT / "data"
+DATA_DIR = REPO_ROOT / os.getenv("DATA_DIR", "data")
 HARDWARE_DIR = REPO_ROOT / "configs" / "hardware"
 OUTPUT_PATH = Path(__file__).resolve().parent.parent / "src" / "data" / "operators.json"
 

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -1,4 +1,5 @@
 ---
+import { siteConfig } from '../config';
 ---
 
 <footer class="border-t border-gray-800/50 bg-gray-950">
@@ -7,7 +8,7 @@
       <p class="text-gray-600 text-xs">
         <span data-i18n="footer.built">Built with</span> Astro + Tailwind CSS
       </p>
-      <a href="https://github.com/alibaba/atrex-bench"
+      <a href={siteConfig.githubRepo}
          target="_blank"
          class="text-gray-500 hover:text-white text-sm transition-colors">
         GitHub

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,5 +1,6 @@
 ---
 import operatorData from '../data/operators.json';
+import { siteConfig } from '../config';
 const { stats } = operatorData;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
@@ -28,7 +29,7 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
       </p>
 
       <div class="flex items-center justify-center gap-4 mb-16">
-        <a href="https://github.com/alibaba/atrex-bench" target="_blank"
+        <a href={siteConfig.githubRepo} target="_blank"
            class="inline-flex items-center gap-2 px-6 py-3 bg-brand-700 hover:bg-brand-600 text-white rounded-lg font-medium transition-colors">
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
           <span data-i18n="hero.cta.github">View on GitHub</span>

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -3,6 +3,7 @@ interface Props {
   currentPath: string;
 }
 const { currentPath } = Astro.props;
+import { siteConfig } from '../config';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
 const docPages = [
@@ -62,7 +63,7 @@ const isDocActive = docPages.some(p => isActive(p.href));
           <button data-lang-btn="en" class="text-xs px-2.5 py-1 rounded-full transition-colors text-white">EN</button>
         </div>
 
-        <a href="https://github.com/alibaba/atrex-bench"
+        <a href={siteConfig.githubRepo}
            target="_blank" rel="noopener noreferrer"
            class="text-gray-400 hover:text-white transition-colors ml-1">
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>

--- a/site/src/components/OperatorCatalog.astro
+++ b/site/src/components/OperatorCatalog.astro
@@ -1,12 +1,13 @@
 ---
 import operatorData from '../data/operators.json';
+import { siteConfig } from '../config';
 const { operators } = operatorData;
 
 const dtypes = [...new Set(operators.map((o: any) => o.dtype))].sort();
 const frameworks = [...new Set(operators.map((o: any) => o.framework))].sort();
 const phases = [...new Set(operators.map((o: any) => o.phase))].sort();
 
-const prodSku = 'XPU-A';
+const prodSku = siteConfig.prodSku;
 
 function regimeBadge(regime: string) {
   if (regime === 'compute-bound') return 'bg-red-900/40 text-red-300 border-red-800';

--- a/site/src/components/QuickStart.astro
+++ b/site/src/components/QuickStart.astro
@@ -1,4 +1,5 @@
 ---
+import { siteConfig } from '../config';
 ---
 
 <div class="page-section">
@@ -18,7 +19,7 @@
     --device=/dev/kfd --device=/dev/dri --group-add video \
     -e ANTHROPIC_API_KEY -e OPENAI_API_KEY \
     -v $PWD:/workspace \
-    {'<YOUR_REGISTRY>'}/atrex-bench:rocm7.2</code></pre>
+    {siteConfig.dockerImage}</code></pre>
       </div>
 
       <div class="card">
@@ -33,7 +34,7 @@
         </p>
         <pre class="code-block"><code>python scripts/run_eval.py \
   --input path/to/candidate.py \
-  --reference-dir data/fused_moe \
+  --reference-dir {siteConfig.dataDir}/fused_moe \
   --output results/run</code></pre>
       </div>
 

--- a/site/src/components/RooflineDetail.astro
+++ b/site/src/components/RooflineDetail.astro
@@ -1,13 +1,10 @@
 ---
 import operatorData from '../data/operators.json';
+import { siteConfig } from '../config';
 const { operators, hardware, hardware_specs } = operatorData;
 
-const hwShort: Record<string, string> = {
-  'XPU-A': 'XPU-A',
-  'H20': 'H20',
-};
-
-const prodHardware = ['XPU-A', 'H20'];
+const hwShort = siteConfig.hwShort;
+const prodHardware = siteConfig.prodHardware;
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---

--- a/site/src/components/ShapeView.astro
+++ b/site/src/components/ShapeView.astro
@@ -1,14 +1,11 @@
 ---
 import operatorData from '../data/operators.json';
+import { siteConfig } from '../config';
 const { operators, hardware, hardware_specs } = operatorData;
 const hwSpecs = hardware_specs as Record<string, Record<string, any>>;
 
-const hwShort: Record<string, string> = {
-  'XPU-A': 'XPU-A',
-  'H20': 'H20',
-};
-
-const prodHardware = ['XPU-A', 'H20'];
+const hwShort = siteConfig.hwShort;
+const prodHardware = siteConfig.prodHardware;
 
 type PerHw = Record<string, number | null>;
 

--- a/site/src/config.ts
+++ b/site/src/config.ts
@@ -1,0 +1,17 @@
+function json<T>(raw: string | undefined, fallback: T): T {
+  if (!raw) return fallback;
+  try { return JSON.parse(raw) as T; } catch { return fallback; }
+}
+
+export const siteConfig = {
+  githubRepo:   import.meta.env.GITHUB_REPO   || 'https://github.com/alibaba/atrex-bench',
+  dockerImage:  import.meta.env.DOCKER_IMAGE   || '<YOUR_REGISTRY>/atrex-bench:rocm7.2',
+  dataDir:      import.meta.env.DATA_DIR       || 'data',
+  defaultHw:    import.meta.env.DEFAULT_HW     || 'XPU-A',
+  prodSku:      import.meta.env.PROD_SKU       || 'XPU-A',
+  prodHardware: json<string[]>(import.meta.env.PROD_HARDWARE, ['XPU-A', 'H20']),
+  hwShort:      json<Record<string, string>>(import.meta.env.HW_SHORT, {
+    'XPU-A': 'XPU-A',
+    'H20':   'H20',
+  }),
+};

--- a/site/src/i18n/en.json
+++ b/site/src/i18n/en.json
@@ -83,7 +83,7 @@
   "operators.chart.subtitle": "Importance score reflects trace-derived GPU time share across production workloads",
 
   "data.page.title": "Benchmark Data",
-  "data.page.subtitle": "30 production operators with 440 hot shapes, importance weights from 1,303 production profiles, roofline bounds across 2 hardware platforms, and deployed kernel baselines.",
+  "data.page.subtitle": "",
 
   "quickstart.title": "Quick Start",
   "quickstart.intro": "Get up and running with Atrex-Bench in minutes using Docker and the built-in CLI tools.",

--- a/site/src/pages/data.astro
+++ b/site/src/pages/data.astro
@@ -5,6 +5,9 @@ import OperatorCatalog from '../components/OperatorCatalog.astro';
 import OperatorChart from '../components/OperatorChart.astro';
 import RooflineDetail from '../components/RooflineDetail.astro';
 import ShapeView from '../components/ShapeView.astro';
+import operatorData from '../data/operators.json';
+const { stats } = operatorData as any;
+const subtitle = `${stats.operators} production operators with ${stats.shapes} hot shapes, importance weights from ${stats.traces_profiled.toLocaleString()} production profiles, roofline bounds across ${stats.hardware} hardware platforms, and deployed kernel baselines.`;
 ---
 
 <Layout title="Data — Atrex-Bench">
@@ -12,7 +15,7 @@ import ShapeView from '../components/ShapeView.astro';
     titleKey="data.page.title"
     titleFallback="Benchmark Data"
     subtitleKey="data.page.subtitle"
-    subtitleFallback="30 production operators with 440 hot shapes, importance weights from 1,303 production profiles, roofline bounds across 2 hardware platforms, and deployed kernel baselines."
+    subtitleFallback={subtitle}
   />
 
   <!-- Tab switcher -->

--- a/site/src/pages/operator/[id].astro
+++ b/site/src/pages/operator/[id].astro
@@ -26,13 +26,10 @@ export function getStaticPaths() {
 
 const { op } = Astro.props as { op: any };
 const { hardware, hardware_specs } = operatorData as any;
+import { siteConfig } from '../../config';
 
-const hwShort: Record<string, string> = {
-  'XPU-A': 'XPU-A',
-  'H20': 'H20',
-};
-
-const defaultHw = 'XPU-A';
+const hwShort = siteConfig.hwShort;
+const defaultHw = siteConfig.defaultHw;
 const details = op.shape_details || {};
 const shapeIds = Object.keys(details).sort((a, b) => parseInt(a) - parseInt(b));
 const hwList = hardware as string[];


### PR DESCRIPTION
**What changed:**

- All deployment-specific values that were previously hardcoded across 13 site files are now centralized into a single site/src/config.ts module, with defaults overridable via environment variables.

- New files:
  - site/src/config.ts — exports siteConfig object; each field reads from an env var with a fallback default
  - site/.env — documents every configurable variable with current defaults

- Config-driven astro.config.mjs:
  - site and base now read from SITE_URL / SITE_BASE env vars (defaults unchanged)

- Config-driven extract-data.py:
  - Data directory read from DATA_DIR env var (defaults to data)