### PR TITLE
feat: align MoE baselines and restore optional SOL floors

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,10 @@ Most are trace-derived (`status: "trace_reference"`); the rest are curated.
 When adding or reshaping operator data, keep `shapes.json` and `roofline.json` aligned and
 refresh `SOL_time_ms` through `scripts/roofline.py`.
 
+See [SOL semantics](docs/roofline_semantics.md) for the optional dispatch-latency
+floor. Use `scripts/static_roofline_check.py` to validate saved SOL values and
+compare them with production latency on the matching device without running kernels.
+
 ## Citation
 
 Please cite our [paper](https://arxiv.org/abs/2607.14541) if it is helpful to your research.

--- a/data/fused_moe/input.py
+++ b/data/fused_moe/input.py
@@ -1,9 +1,29 @@
 import torch
 
-def _make_inputs(token_count: int, hidden_size: int, intermediate_size: int, num_experts: int, top_k: int) -> dict[str, torch.Tensor]:
-    hidden_states = torch.randn(token_count, hidden_size, dtype=torch.bfloat16, device='cuda') * 0.1
-    w1 = torch.randn(num_experts, 2 * intermediate_size, hidden_size, dtype=torch.bfloat16, device='cuda') * hidden_size ** (-0.5)
-    w2 = torch.randn(num_experts, hidden_size, intermediate_size, dtype=torch.bfloat16, device='cuda') * intermediate_size ** (-0.5)
-    topk_weights = torch.softmax(torch.randn(token_count, top_k, dtype=torch.float32, device='cuda'), dim=-1)
-    topk_ids = torch.randint(0, num_experts, (token_count, top_k), dtype=torch.int32, device='cuda')
-    return {'hidden_states': hidden_states, 'w1': w1, 'w2': w2, 'topk_weights': topk_weights, 'topk_ids': topk_ids}
+
+def _make_inputs(
+    token_count: int, hidden_size: int, intermediate_size: int, num_experts: int, top_k: int
+) -> dict[str, torch.Tensor]:
+    hidden_states = torch.randn(token_count, hidden_size, dtype=torch.bfloat16, device="cuda") * 0.1
+    w1 = torch.randn(
+        num_experts, 2 * intermediate_size, hidden_size, dtype=torch.bfloat16, device="cuda"
+    ) * hidden_size ** (-0.5)
+    w2 = torch.randn(
+        num_experts, hidden_size, intermediate_size, dtype=torch.bfloat16, device="cuda"
+    ) * intermediate_size ** (-0.5)
+    # Realistic top-k routing: select top_k experts per token from router logits so that
+    # each token's selected experts are unique (real MoE never routes a token to the same
+    # expert twice). Using torch.randint here instead would produce duplicate experts per
+    # token, an unphysical case that sorted-scatter MoE kernels handle differently from the
+    # gather reference, spuriously failing accuracy checks.
+    router_logits = torch.randn(token_count, num_experts, dtype=torch.float32, device="cuda")
+    topk_weights, topk_ids = torch.topk(router_logits.softmax(dim=-1), top_k, dim=-1)
+    topk_weights = (topk_weights / topk_weights.sum(dim=-1, keepdim=True)).to(torch.float32)
+    topk_ids = topk_ids.to(torch.int32)
+    return {
+        "hidden_states": hidden_states,
+        "w1": w1,
+        "w2": w2,
+        "topk_weights": topk_weights,
+        "topk_ids": topk_ids,
+    }

--- a/data/fused_moe/metadata.json
+++ b/data/fused_moe/metadata.json
@@ -26,8 +26,8 @@
       "source_repo": "atrex-bench",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 300.2
+          "framework": "aiter",
+          "performance_us": 232.72
         }
       }
     },
@@ -37,8 +37,8 @@
       "source_repo": "atrex-bench",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 473.44
+          "framework": "aiter",
+          "performance_us": 249.85
         }
       }
     },
@@ -48,8 +48,8 @@
       "source_repo": "atrex-bench",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 654.15
+          "framework": "aiter",
+          "performance_us": 477.13
         }
       }
     },
@@ -59,8 +59,8 @@
       "source_repo": "atrex-bench",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 947.09
+          "framework": "aiter",
+          "performance_us": 538.98
         }
       }
     },
@@ -70,8 +70,8 @@
       "source_repo": "atrex-bench",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 1461.2
+          "framework": "aiter",
+          "performance_us": 772.52
         }
       }
     },
@@ -81,8 +81,8 @@
       "source_repo": "atrex-bench",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 3109.21
+          "framework": "aiter",
+          "performance_us": 1602.87
         }
       }
     },
@@ -92,8 +92,8 @@
       "source_repo": "atrex-bench",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 5987.18
+          "framework": "aiter",
+          "performance_us": 2680.33
         }
       }
     },
@@ -103,8 +103,8 @@
       "source_repo": "atrex-bench",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 14360.39
+          "framework": "aiter",
+          "performance_us": 5369.44
         }
       }
     },
@@ -114,8 +114,8 @@
       "tensor_parallel_size": 1,
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 225.92
+          "framework": "aiter",
+          "performance_us": 116.91
         }
       }
     },
@@ -125,8 +125,8 @@
       "call_count": 48,
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 3698.47
+          "framework": "aiter",
+          "performance_us": 2159.35
         }
       }
     },
@@ -136,11 +136,11 @@
       "source_kernel_name": "fused_moe_kernel",
       "source_framework": "sglang",
       "call_count": 80,
-      "total_duration_us": 86361.0,
+      "total_duration_us": 86361,
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 5846.86
+          "framework": "aiter",
+          "performance_us": 2981.52
         }
       }
     },
@@ -150,8 +150,8 @@
       "call_count": 48,
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 10565.14
+          "framework": "aiter",
+          "performance_us": 4988.52
         }
       }
     },
@@ -161,11 +161,11 @@
       "source_kernel_name": "fused_moe_kernel",
       "source_framework": "sglang",
       "call_count": 80,
-      "total_duration_us": 260805.0,
+      "total_duration_us": 260805,
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 22238.15
+          "framework": "aiter",
+          "performance_us": 9092.71
         }
       }
     },
@@ -175,8 +175,8 @@
       "call_count": 48,
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 40109.11
+          "framework": "aiter",
+          "performance_us": 14476.9
         }
       }
     },
@@ -186,8 +186,8 @@
       "call_count": 48,
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 76815.05
+          "framework": "aiter",
+          "performance_us": 25710.35
         }
       }
     },
@@ -196,8 +196,8 @@
       "source_framework": "vllm",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 1261.98
+          "framework": "aiter",
+          "performance_us": 595.76
         }
       }
     },
@@ -206,8 +206,8 @@
       "source_framework": "vllm",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 1890.97
+          "framework": "aiter",
+          "performance_us": 882.87
         }
       }
     },
@@ -216,8 +216,8 @@
       "source_framework": "vllm",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 3325.66
+          "framework": "aiter",
+          "performance_us": 1606.43
         }
       }
     },
@@ -226,8 +226,8 @@
       "source_framework": "vllm",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 5694.2
+          "framework": "aiter",
+          "performance_us": 2798.95
         }
       }
     },
@@ -236,8 +236,8 @@
       "source_framework": "vllm",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 11595.71
+          "framework": "aiter",
+          "performance_us": 5694.95
         }
       }
     },
@@ -247,8 +247,8 @@
       "source_repo": "atrex-bench",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 11607.73
+          "framework": "aiter",
+          "performance_us": 5329.39
         }
       }
     },
@@ -258,8 +258,8 @@
       "source_repo": "atrex-bench",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 32255.24
+          "framework": "aiter",
+          "performance_us": 10095.13
         }
       }
     },
@@ -269,8 +269,8 @@
       "source_repo": "atrex-bench",
       "production_performance": {
         "XPU-A": {
-          "framework": "sglang",
-          "performance_us": 71529.43
+          "framework": "aiter",
+          "performance_us": 18643.47
         }
       }
     }

--- a/docs/roofline_semantics.md
+++ b/docs/roofline_semantics.md
@@ -1,0 +1,27 @@
+# SOL calculation and optional dispatch floor
+
+The theoretical latency is `max(sum(W[d] / P_peak[d]), Q / B_peak)`.
+An empty dtype mapping denotes memory-only work; zero compute and zero traffic
+produce zero latency. Memory traffic alone is not an empty workload.
+
+A hardware profile may explicitly set `launch_overhead_s` to a finite positive
+number in seconds. Missing or `null` means no floor. For nonempty work, the
+reported SOL becomes `max(theoretical_latency, launch_overhead_s)`;
+`clamped_by_overhead` indicates that the floor raised the result. The bottleneck,
+arithmetic intensity and roofline throughput describe the theoretical model,
+not dispatch overhead. This optional latency-floor model is not a pure roofline
+bound and must be identified when comparing results.
+
+Only use a floor measured for the execution/timing mode being compared. In
+particular, do not reuse an eager-dispatch measurement for CUDA Graph replay
+without validation. No default floor or device-specific value is hardcoded.
+
+The Python API and `scripts/roofline.py` use the same floor semantics, including
+integer-only operators. JSON output includes the clamp flag; text labels a
+clamped result. Existing `SOL_time_ms` caches are not automatically migrated.
+Review with `--no-write` before explicitly recomputing an operator's cache.
+
+The fused MoE bundle uses distinct top-k expert routes with normalized weights.
+Its XPU-A production baselines are recorded AITER measurements, not measurements
+performed by this migration. Reproduction requires matching hardware, framework
+versions and timing conditions.

--- a/scripts/roofline.py
+++ b/scripts/roofline.py
@@ -41,6 +41,7 @@ from atrex_bench.eval.roofline import (
     DTYPE_PATHS,
     RooflineHardware,
     RooflineResult,
+    apply_launch_overhead,
     compute_roofline,
     compute_roofline_hybrid,
     load_hardware,
@@ -107,7 +108,8 @@ def _format_text_standalone(
         "",
         "Roofline:",
         f"  P_roof:        {_format_tflops(result.p_roof_flops_per_s)}",
-        f"  T_SOL:         {result.sol_time_ms:.4f} ms",
+        f"  T_SOL:         {result.sol_time_ms:.4f} ms"
+        + (" (launch-overhead floor)" if result.clamped_by_overhead else ""),
         f"  Bottleneck:    {result.bottleneck}",
     ]
     return "\n".join(lines)
@@ -746,6 +748,8 @@ def _shape_compute(
             f"shape {shape_id!r}: semantic_Q_*_bytes must be numbers, got "
             f"read={q_read!r}, write={q_write!r}."
         )
+    if q_read < 0 or q_write < 0:
+        raise ValueError(f"shape {shape_id!r}: semantic_Q_*_bytes must be non-negative")
     q_read_int = int(q_read)
     q_write_int = int(q_write)
     q_total = q_read_int + q_write_int
@@ -753,15 +757,17 @@ def _shape_compute(
     if not w_by_dtype:
         # Integer-only / no-FP operator: no compute peak applies; SOL = Q/B_peak.
         sol_time_s = q_total / hw.b_peak_hbm if hw.b_peak_hbm > 0 else 0.0
+        sol_time_s, clamped = apply_launch_overhead(sol_time_s, hw)
         result = RooflineResult(
             arithmetic_intensity=0.0,
             ridge_point_ai=0.0,
             p_roof_flops_per_s=0.0,
             sol_time_s=sol_time_s,
             sol_time_ms=sol_time_s * 1000.0,
-            bottleneck="memory",
+            bottleneck="memory" if q_total else "no_compute",
             p_peak_used=0,
             b_peak_used=hw.b_peak_hbm,
+            clamped_by_overhead=clamped,
         )
     elif len(w_by_dtype) == 1:
         only_dtype = next(iter(w_by_dtype))
@@ -809,6 +815,7 @@ def _format_text_per_op(
             f"{row['p_roof_tflops']:>11.2f} TF "
             f"{row['sol_time_ms']:>11.4f} ms "
             f"{row['bottleneck']:>12}"
+            + (" (launch-overhead floor)" if row["clamped_by_overhead"] else "")
         )
     return "\n".join(lines)
 
@@ -930,6 +937,7 @@ def _run_per_operator(args: argparse.Namespace) -> int:
                 "p_roof_tflops": result.p_roof_flops_per_s / 1e12,
                 "sol_time_ms": result.sol_time_ms,
                 "bottleneck": result.bottleneck,
+                "clamped_by_overhead": result.clamped_by_overhead,
             }
         )
 

--- a/scripts/static_roofline_check.py
+++ b/scripts/static_roofline_check.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Static checks for production roofline SOL numbers.
+
+This intentionally does not import or execute operator input/reference modules.
+It only keeps two checks:
+
+1. ``roofline.json`` saved ``SOL_time_ms`` matches recomputation from
+   ``semantic_W_flops`` + ``semantic_Q_*_bytes`` + hardware yaml.
+2. ``T_SOL / TProd`` is above a configurable threshold, default ``0.95``.
+
+Examples:
+  python scripts/static_roofline_check.py --operator fused_moe --verbose
+  python scripts/static_roofline_check.py --format json --output /tmp/check.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    from atrex_bench.eval.roofline import (
+        RooflineHardware,
+        RooflineResult,
+        apply_launch_overhead,
+        compute_roofline,
+        compute_roofline_hybrid,
+        load_hardware,
+    )
+except ModuleNotFoundError:
+    repo_src = Path(__file__).resolve().parents[1] / "src"
+    if str(repo_src) not in sys.path:
+        sys.path.insert(0, str(repo_src))
+    from atrex_bench.eval.roofline import (  # type: ignore[no-redef]
+        RooflineHardware,
+        RooflineResult,
+        apply_launch_overhead,
+        compute_roofline,
+        compute_roofline_hybrid,
+        load_hardware,
+    )
+
+
+@dataclass
+class Issue:
+    severity: str
+    code: str
+    operator: str
+    message: str
+    shape_id: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, tuple):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, float) and math.isinf(value):
+        return "inf"
+    return value
+
+
+def _load_hardware_profiles(hardware_dir: Path) -> dict[str, RooflineHardware]:
+    profiles: dict[str, RooflineHardware] = {}
+    if not hardware_dir.is_dir():
+        return profiles
+    for path in sorted(hardware_dir.glob("*.yaml")):
+        hw = load_hardware(path)
+        profiles[hw.sku_name] = hw
+    return profiles
+
+
+def _normalize_token(value: str) -> str:
+    return "".join(ch for ch in value.lower() if ch.isalnum())
+
+
+def _match_hardware_alias(alias: str, hardware_names: list[str]) -> list[str]:
+    alias_norm = _normalize_token(alias)
+    if not alias_norm:
+        return []
+
+    matches: list[str] = []
+    for name in hardware_names:
+        name_norm = _normalize_token(name)
+        last_token = _normalize_token(name.split()[-1]) if name.split() else name_norm
+        if alias_norm == name_norm or alias_norm == last_token or alias_norm in name_norm:
+            matches.append(name)
+    return matches
+
+
+def _metadata_hardware_aliases(metadata: dict[str, Any]) -> list[str]:
+    aliases: list[str] = []
+
+    trace_filter = metadata.get("trace_filter")
+    if isinstance(trace_filter, dict):
+        gpu = trace_filter.get("kernel_context_gpu")
+        if isinstance(gpu, str):
+            aliases.append(gpu)
+        elif isinstance(gpu, list):
+            aliases.extend(item for item in gpu if isinstance(item, str))
+
+    trace_gpus = metadata.get("trace_gpus")
+    if isinstance(trace_gpus, list):
+        aliases.extend(item for item in trace_gpus if isinstance(item, str))
+    elif isinstance(trace_gpus, str):
+        aliases.append(trace_gpus)
+
+    return aliases
+
+
+def _latency_hardware_keys(
+    *,
+    metadata: dict[str, Any],
+    sol_keys: list[str],
+    args: argparse.Namespace,
+) -> list[str]:
+    if args.check_all_sol_latency:
+        return sorted(sol_keys)
+
+    requested = args.latency_hardware or []
+    if requested:
+        matches: set[str] = set()
+        for value in requested:
+            if value in sol_keys:
+                matches.add(value)
+            else:
+                matches.update(_match_hardware_alias(value, sol_keys))
+        return sorted(matches)
+
+    matches: set[str] = set()
+    for alias in _metadata_hardware_aliases(metadata):
+        matches.update(_match_hardware_alias(alias, sol_keys))
+    # Public bundles need not retain trace provenance. Use exact baseline device
+    # keys when available; per-shape lookup still requires a matching device.
+    for shape in (metadata.get("shapes") or {}).values():
+        if isinstance(shape, dict):
+            perf = shape.get("production_performance")
+            if isinstance(perf, dict):
+                matches.update(set(perf).intersection(sol_keys))
+    return sorted(matches)
+
+
+def _production_perf_us(
+    metadata: dict[str, Any],
+    shape_id: str,
+    hardware_name: str,
+) -> float | None:
+    shapes = metadata.get("shapes")
+    if isinstance(shapes, dict):
+        shape_meta = shapes.get(shape_id)
+        if isinstance(shape_meta, dict):
+            perf = shape_meta.get("production_performance")
+            if isinstance(perf, dict):
+                # Never compare one device's SOL with another device's latency.
+                if "performance_us" not in perf:
+                    perf = perf.get(hardware_name, {})
+                value = perf.get("performance_us") if isinstance(perf, dict) else None
+                if isinstance(value, (int, float)) and value > 0:
+                    return float(value)
+
+    # Legacy fallback: top-level production_performance either keyed by shape id
+    # or directly carrying one performance_us value.
+    perf_root = metadata.get("production_performance")
+    if isinstance(perf_root, dict):
+        shape_perf = perf_root.get(shape_id)
+        if isinstance(shape_perf, dict):
+            value = shape_perf.get("performance_us")
+            if isinstance(value, (int, float)) and value > 0:
+                return float(value)
+        value = perf_root.get("performance_us")
+        if isinstance(value, (int, float)) and value > 0:
+            return float(value)
+
+    return None
+
+
+def _compute_static_roofline(
+    *,
+    shape_id: str,
+    shape_block: dict[str, Any],
+    hw: RooflineHardware,
+) -> RooflineResult:
+    semantic_w = shape_block.get("semantic_W_flops")
+    if not isinstance(semantic_w, dict):
+        raise ValueError(f"shape {shape_id}: semantic_W_flops must be a mapping.")
+
+    w_by_dtype: dict[str, int] = {}
+    for dtype, value in semantic_w.items():
+        if not isinstance(value, (int, float)) or value < 0:
+            raise ValueError(
+                f"shape {shape_id}: semantic_W_flops[{dtype!r}] must be non-negative numeric."
+            )
+        w_by_dtype[str(dtype)] = int(value)
+
+    q_read = shape_block.get("semantic_Q_read_bytes")
+    q_write = shape_block.get("semantic_Q_write_bytes")
+    if not isinstance(q_read, (int, float)) or not isinstance(q_write, (int, float)):
+        raise ValueError(f"shape {shape_id}: semantic_Q_*_bytes must be numeric.")
+    if q_read < 0 or q_write < 0:
+        raise ValueError(f"shape {shape_id}: semantic_Q_*_bytes must be non-negative.")
+
+    q_total = int(q_read) + int(q_write)
+    if not w_by_dtype:
+        sol_time_s = q_total / hw.b_peak_hbm if hw.b_peak_hbm > 0 else 0.0
+        sol_time_s, clamped = apply_launch_overhead(sol_time_s, hw)
+        return RooflineResult(
+            arithmetic_intensity=0.0,
+            ridge_point_ai=0.0,
+            p_roof_flops_per_s=0.0,
+            sol_time_s=sol_time_s,
+            sol_time_ms=sol_time_s * 1000.0,
+            bottleneck="memory" if q_total > 0 else "no_compute",
+            p_peak_used=0,
+            b_peak_used=hw.b_peak_hbm,
+            clamped_by_overhead=clamped,
+        )
+
+    if len(w_by_dtype) == 1:
+        dtype, w_flops = next(iter(w_by_dtype.items()))
+        return compute_roofline(w_flops, q_total, dtype, hw)
+    return compute_roofline_hybrid(w_by_dtype, q_total, hw)
+
+
+def _check_sol_matches_wq(
+    *,
+    operator: str,
+    roof_shapes: dict[str, Any],
+    hardware_by_name: dict[str, RooflineHardware],
+    args: argparse.Namespace,
+    issues: list[Issue],
+) -> None:
+    for shape_id, shape_block in roof_shapes.items():
+        if not isinstance(shape_block, dict):
+            issues.append(
+                Issue(
+                    severity="ERROR",
+                    code="SOL_WQ_INCONSISTENT",
+                    operator=operator,
+                    shape_id=shape_id,
+                    message="roofline shape entry must be a mapping.",
+                )
+            )
+            continue
+
+        sol = shape_block.get("SOL_time_ms")
+        if not isinstance(sol, dict):
+            issues.append(
+                Issue(
+                    severity="ERROR",
+                    code="SOL_WQ_INCONSISTENT",
+                    operator=operator,
+                    shape_id=shape_id,
+                    message="SOL_time_ms must be a hardware-name mapping.",
+                )
+            )
+            continue
+
+        for hw_name, saved_sol in sol.items():
+            if saved_sol is None:
+                continue
+            hw = hardware_by_name.get(hw_name)
+            if hw is None:
+                issues.append(
+                    Issue(
+                        severity="ERROR",
+                        code="SOL_WQ_INCONSISTENT",
+                        operator=operator,
+                        shape_id=shape_id,
+                        message=f"SOL_time_ms hardware key {hw_name!r} has no hardware yaml.",
+                    )
+                )
+                continue
+            if not isinstance(saved_sol, (int, float)) or saved_sol < 0:
+                issues.append(
+                    Issue(
+                        severity="ERROR",
+                        code="SOL_WQ_INCONSISTENT",
+                        operator=operator,
+                        shape_id=shape_id,
+                        message=f"SOL_time_ms[{hw_name!r}] must be non-negative numeric or null.",
+                    )
+                )
+                continue
+
+            try:
+                expected = _compute_static_roofline(
+                    shape_id=shape_id,
+                    shape_block=shape_block,
+                    hw=hw,
+                ).sol_time_ms
+            except Exception as exc:  # noqa: BLE001 - checker should report data problems
+                issues.append(
+                    Issue(
+                        severity="ERROR",
+                        code="SOL_WQ_INCONSISTENT",
+                        operator=operator,
+                        shape_id=shape_id,
+                        message=f"could not recompute SOL_time_ms[{hw_name!r}]: {exc}",
+                    )
+                )
+                continue
+
+            diff = abs(float(saved_sol) - expected)
+            rel = diff / max(abs(expected), 1e-30)
+            if diff > args.sol_abs_tol_ms and rel > args.sol_rel_tol:
+                issues.append(
+                    Issue(
+                        severity="ERROR",
+                        code="SOL_WQ_INCONSISTENT",
+                        operator=operator,
+                        shape_id=shape_id,
+                        message=f"SOL_time_ms[{hw_name!r}] does not match W/Q/hardware recompute.",
+                        details={
+                            "hardware": hw_name,
+                            "saved_ms": saved_sol,
+                            "expected_ms": expected,
+                            "abs_diff_ms": diff,
+                            "rel_diff": rel,
+                        },
+                    )
+                )
+
+
+def _check_sol_prod_ratio(
+    *,
+    operator: str,
+    metadata: dict[str, Any],
+    roof_shapes: dict[str, Any],
+    args: argparse.Namespace,
+    issues: list[Issue],
+) -> None:
+    for shape_id, shape_block in roof_shapes.items():
+        if not isinstance(shape_block, dict):
+            continue
+        sol = shape_block.get("SOL_time_ms")
+        if not isinstance(sol, dict):
+            continue
+        hw_keys = _latency_hardware_keys(
+            metadata=metadata,
+            sol_keys=[str(key) for key in sol],
+            args=args,
+        )
+        if not hw_keys:
+            continue
+
+        for hw_name in hw_keys:
+            perf_us = _production_perf_us(metadata, str(shape_id), hw_name)
+            if perf_us is None:
+                continue
+            prod_ms = perf_us / 1000.0
+            sol_ms = sol.get(hw_name)
+            if not isinstance(sol_ms, (int, float)):
+                continue
+            ratio = float(sol_ms) / prod_ms
+            if ratio > 1.0:
+                issues.append(
+                    Issue(
+                        severity="WARN",
+                        code="SOL_EXCEEDS_PRODUCTION",
+                        operator=operator,
+                        shape_id=shape_id,
+                        message=(
+                            f"S={ratio:.2%} > 100%: candidate runs faster "
+                            f"than SOL floor. Check launch_overhead_s for "
+                            f"{hw_name}."
+                        ),
+                        details={
+                            "hardware": hw_name,
+                            "sol_ms": sol_ms,
+                            "production_ms": prod_ms,
+                            "production_us": perf_us,
+                            "sol_over_tprod": ratio,
+                        },
+                    )
+                )
+            elif ratio > args.sol_prod_threshold:
+                issues.append(
+                    Issue(
+                        severity="WARN",
+                        code="HIGH_SOL_PROD_RATIO",
+                        operator=operator,
+                        shape_id=shape_id,
+                        message=(f"T_SOL/TProd={ratio:.4f} exceeds {args.sol_prod_threshold:.4f}."),
+                        details={
+                            "hardware": hw_name,
+                            "sol_ms": sol_ms,
+                            "production_ms": prod_ms,
+                            "production_us": perf_us,
+                            "sol_over_tprod": ratio,
+                        },
+                    )
+                )
+
+
+def _operator_dirs(data_root: Path, selected: list[str] | None) -> list[Path]:
+    if selected:
+        return [data_root / name for name in selected]
+    return sorted(path for path in data_root.iterdir() if path.is_dir())
+
+
+def _check_operator(
+    *,
+    op_dir: Path,
+    hardware_by_name: dict[str, RooflineHardware],
+    args: argparse.Namespace,
+    issues: list[Issue],
+) -> None:
+    operator = op_dir.name
+    required = {
+        "metadata": op_dir / "metadata.json",
+        "roofline": op_dir / "roofline.json",
+    }
+    missing = [name for name, path in required.items() if not path.exists()]
+    if missing:
+        issues.append(
+            Issue(
+                severity="ERROR",
+                code="SOL_WQ_INCONSISTENT",
+                operator=operator,
+                message=f"operator is missing required files: {missing}",
+            )
+        )
+        return
+
+    try:
+        metadata = _load_json(required["metadata"])
+        roofline = _load_json(required["roofline"])
+    except Exception as exc:  # noqa: BLE001 - malformed data is a checker finding
+        issues.append(
+            Issue(
+                severity="ERROR",
+                code="SOL_WQ_INCONSISTENT",
+                operator=operator,
+                message=f"failed to load metadata/roofline json: {exc}",
+            )
+        )
+        return
+
+    if not isinstance(metadata, dict) or not isinstance(roofline, dict):
+        issues.append(
+            Issue(
+                severity="ERROR",
+                code="SOL_WQ_INCONSISTENT",
+                operator=operator,
+                message="metadata.json and roofline.json top-level values must be mappings.",
+            )
+        )
+        return
+
+    roof_shapes = roofline.get("shapes")
+    if not isinstance(roof_shapes, dict):
+        issues.append(
+            Issue(
+                severity="ERROR",
+                code="SOL_WQ_INCONSISTENT",
+                operator=operator,
+                message="roofline.json top-level shapes must be a mapping.",
+            )
+        )
+        return
+
+    _check_sol_matches_wq(
+        operator=operator,
+        roof_shapes=roof_shapes,
+        hardware_by_name=hardware_by_name,
+        args=args,
+        issues=issues,
+    )
+    _check_sol_prod_ratio(
+        operator=operator,
+        metadata=metadata,
+        roof_shapes=roof_shapes,
+        args=args,
+        issues=issues,
+    )
+
+
+def _format_issue(issue: Issue, *, verbose: bool) -> str:
+    location = issue.operator
+    if issue.shape_id is not None:
+        location += f" sid={issue.shape_id}"
+    line = f"[{issue.severity}] {location} {issue.code}: {issue.message}"
+    if verbose and issue.details:
+        line += "\n  details: " + json.dumps(_jsonable(issue.details), sort_keys=True)
+    return line
+
+
+def _format_text(issues: list[Issue], *, verbose: bool, max_issues: int) -> str:
+    counts = {"ERROR": 0, "WARN": 0}
+    for issue in issues:
+        counts[issue.severity] = counts.get(issue.severity, 0) + 1
+
+    lines = [
+        (
+            "Static roofline check: "
+            f"{counts.get('ERROR', 0)} error(s), "
+            f"{counts.get('WARN', 0)} warning(s)."
+        )
+    ]
+    if not issues:
+        return "\n".join(lines)
+
+    severity_rank = {"ERROR": 0, "WARN": 1}
+    ordered = sorted(
+        issues,
+        key=lambda item: (
+            severity_rank.get(item.severity, 99),
+            item.operator,
+            item.shape_id or "",
+            item.code,
+        ),
+    )
+    shown = ordered if max_issues <= 0 else ordered[:max_issues]
+    lines.append("")
+    lines.extend(_format_issue(issue, verbose=verbose) for issue in shown)
+    if max_issues > 0 and len(ordered) > max_issues:
+        lines.append(f"... {len(ordered) - max_issues} more issue(s) omitted.")
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    repo_root = Path(__file__).resolve().parents[1]
+    parser.add_argument("--data-root", type=Path, default=repo_root / "data")
+    parser.add_argument("--hardware-dir", type=Path, default=repo_root / "configs" / "hardware")
+    parser.add_argument(
+        "--operator",
+        action="append",
+        dest="operators",
+        help="Operator directory name under --data-root. Repeat to check multiple operators.",
+    )
+    parser.add_argument(
+        "--latency-hardware",
+        action="append",
+        help=(
+            "Hardware name or alias for T_SOL/TProd checks. Defaults to "
+            "metadata.trace_gpus / metadata.trace_filter inference."
+        ),
+    )
+    parser.add_argument(
+        "--check-all-sol-latency",
+        action="store_true",
+        help="Compare production latency against every SOL_time_ms hardware key.",
+    )
+    parser.add_argument("--sol-prod-threshold", type=float, default=0.95)
+    parser.add_argument("--sol-abs-tol-ms", type=float, default=1e-9)
+    parser.add_argument("--sol-rel-tol", type=float, default=1e-6)
+    parser.add_argument("--warnings-as-errors", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--max-issues", type=int, default=120, help="0 means no limit.")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--output", type=Path, default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    hardware_by_name = _load_hardware_profiles(args.hardware_dir)
+    issues: list[Issue] = []
+    if not hardware_by_name:
+        issues.append(
+            Issue(
+                severity="ERROR",
+                code="SOL_WQ_INCONSISTENT",
+                operator="(global)",
+                message=f"no hardware profiles found under {args.hardware_dir}",
+            )
+        )
+
+    op_dirs = _operator_dirs(args.data_root, args.operators)
+    if not op_dirs:
+        parser.error(f"No operator directories found under {args.data_root}")
+    for op_dir in op_dirs:
+        _check_operator(
+            op_dir=op_dir,
+            hardware_by_name=hardware_by_name,
+            args=args,
+            issues=issues,
+        )
+
+    if args.warnings_as_errors:
+        has_failure = any(issue.severity in {"ERROR", "WARN"} for issue in issues)
+    else:
+        has_failure = any(issue.severity == "ERROR" for issue in issues)
+
+    if args.format == "json":
+        payload = {
+            "passed": not has_failure,
+            "issue_counts": {
+                "ERROR": sum(1 for issue in issues if issue.severity == "ERROR"),
+                "WARN": sum(1 for issue in issues if issue.severity == "WARN"),
+            },
+            "issues": [_jsonable(asdict(issue)) for issue in issues],
+        }
+        text = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+    else:
+        text = _format_text(issues, verbose=args.verbose, max_issues=args.max_issues) + "\n"
+
+    if args.output is None:
+        print(text, end="")
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+        print(f"[OUTPUT] {args.output}")
+
+    return 1 if has_failure else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/atrex_bench/eval/roofline.py
+++ b/src/atrex_bench/eval/roofline.py
@@ -54,6 +54,11 @@ class RooflineHardware:
     Loaded from configs/hardware/<sku>.yaml in the unified spec-only schema
     (commit 54d5bb8). ``p_peak`` is keyed by the path string (e.g. ``bf16_tc``)
     not the short dtype name.
+
+    ``launch_overhead_s`` is the empirically measured minimum kernel dispatch
+    latency on this SKU. When set, roofline SOL is clamped:
+    ``sol_time_s = max(sol_time_s, launch_overhead_s)`` so tiny operators
+    cannot report sub-overhead SOL times.
     """
 
     sku_name: str
@@ -63,6 +68,17 @@ class RooflineHardware:
     p_peak: dict[str, int]  # path string -> FLOPs/s
     b_peak_hbm: int  # bytes/s
     source_doc: str
+    launch_overhead_s: float | None = None
+
+    def __post_init__(self) -> None:
+        value = self.launch_overhead_s
+        if value is not None and (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+            or value <= 0
+        ):
+            raise ValueError("launch_overhead_s must be a finite positive number or null")
 
 
 @dataclass(frozen=True)
@@ -72,11 +88,12 @@ class RooflineResult:
     arithmetic_intensity: float  # W / Q (FLOPs per byte); inf when Q == 0
     ridge_point_ai: float  # P_peak / B_peak (machine balance)
     p_roof_flops_per_s: float  # min(P_peak, AI * B_peak)
-    sol_time_s: float  # W / P_roof; 0.0 when W == 0
+    sol_time_s: float  # max(roofline, launch_overhead); 0.0 when W==Q==0
     sol_time_ms: float  # SOL in milliseconds
     bottleneck: Bottleneck
     p_peak_used: int
     b_peak_used: int
+    clamped_by_overhead: bool = False  # True when launch_overhead_s raised the SOL
 
 
 _RIDGE_BAND = 0.05  # +/-5% around ridge AI counts as balanced
@@ -96,9 +113,7 @@ def resolve_dtype_path(dtype: str) -> str:
     if dtype in DTYPE_PATHS.values():
         return dtype
     known = sorted(set(list(DTYPE_PATHS) + list(DTYPE_PATHS.values())))
-    raise ValueError(
-        f"Unknown dtype: {dtype!r}. Known dtype names / paths: {known}."
-    )
+    raise ValueError(f"Unknown dtype: {dtype!r}. Known dtype names / paths: {known}.")
 
 
 def load_hardware(yaml_path: Path) -> RooflineHardware:
@@ -114,9 +129,7 @@ def load_hardware(yaml_path: Path) -> RooflineHardware:
         raise FileNotFoundError(f"Hardware config not found: {yaml_path}")
     raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
-        raise ValueError(
-            f"Hardware config {yaml_path} must be a YAML mapping at top-level."
-        )
+        raise ValueError(f"Hardware config {yaml_path} must be a YAML mapping at top-level.")
 
     hw = raw.get("hardware") or {}
     p_peak_raw = raw.get("p_peak") or {}
@@ -161,14 +174,28 @@ def load_hardware(yaml_path: Path) -> RooflineHardware:
         )
     if not isinstance(b_peak_hbm, (int, float)) or b_peak_hbm <= 0:
         raise ValueError(
-            f"{yaml_path}: b_peak.hbm must be a positive number (bytes/s), "
-            f"got {b_peak_hbm!r}."
+            f"{yaml_path}: b_peak.hbm must be a positive number (bytes/s), got {b_peak_hbm!r}."
         )
     b_peak_hbm_int = int(b_peak_hbm)
 
     source_doc = ""
     if isinstance(source, dict):
         source_doc = str(source.get("vendor_doc") or "")
+
+    launch_overhead_raw = raw.get("launch_overhead_s")
+    launch_overhead_s: float | None = None
+    if launch_overhead_raw is not None:
+        if (
+            isinstance(launch_overhead_raw, bool)
+            or not isinstance(launch_overhead_raw, (int, float))
+            or not math.isfinite(launch_overhead_raw)
+            or launch_overhead_raw <= 0
+        ):
+            raise ValueError(
+                f"{yaml_path}: launch_overhead_s must be a positive number "
+                f"(seconds), got {launch_overhead_raw!r}."
+            )
+        launch_overhead_s = float(launch_overhead_raw)
 
     return RooflineHardware(
         sku_name=str(sku_name),
@@ -178,7 +205,19 @@ def load_hardware(yaml_path: Path) -> RooflineHardware:
         p_peak=cleaned_p_peak,
         b_peak_hbm=b_peak_hbm_int,
         source_doc=source_doc,
+        launch_overhead_s=launch_overhead_s,
     )
+
+
+def apply_launch_overhead(
+    sol_time_s: float,
+    hardware: RooflineHardware,
+) -> tuple[float, bool]:
+    """Apply an explicitly configured latency floor; preserve an empty workload."""
+    floor = hardware.launch_overhead_s
+    if floor is not None and 0.0 < sol_time_s < floor:
+        return float(floor), True
+    return sol_time_s, False
 
 
 def _classify_bottleneck(ai: float, ridge_ai: float) -> Bottleneck:
@@ -208,8 +247,7 @@ def compute_roofline(
 
     if w_flops < 0 or q_bytes < 0:
         raise ValueError(
-            f"w_flops and q_bytes must be non-negative; "
-            f"got w_flops={w_flops}, q_bytes={q_bytes}."
+            f"w_flops and q_bytes must be non-negative; got w_flops={w_flops}, q_bytes={q_bytes}."
         )
 
     path = resolve_dtype_path(dtype)
@@ -251,6 +289,8 @@ def compute_roofline(
     else:
         sol_time_s = w_flops / p_roof
 
+    sol_time_s, clamped = apply_launch_overhead(sol_time_s, hardware)
+
     return RooflineResult(
         arithmetic_intensity=ai,
         ridge_point_ai=ridge_ai,
@@ -260,6 +300,7 @@ def compute_roofline(
         bottleneck=bottleneck,
         p_peak_used=p_peak,
         b_peak_used=b_peak,
+        clamped_by_overhead=clamped,
     )
 
 
@@ -285,9 +326,7 @@ def compute_roofline_hybrid(
     total_w = 0
     for dtype, w in w_flops_by_dtype.items():
         if w < 0:
-            raise ValueError(
-                f"semantic_W_flops[{dtype!r}] must be non-negative, got {w}."
-            )
+            raise ValueError(f"semantic_W_flops[{dtype!r}] must be non-negative, got {w}.")
         path = resolve_dtype_path(dtype)
         if path not in hardware.p_peak:
             raise KeyError(
@@ -333,6 +372,8 @@ def compute_roofline_hybrid(
     else:
         bottleneck = "balanced"
 
+    sol_time_s, clamped = apply_launch_overhead(sol_time_s, hardware)
+
     return RooflineResult(
         arithmetic_intensity=ai,
         ridge_point_ai=ridge_ai,
@@ -342,6 +383,7 @@ def compute_roofline_hybrid(
         bottleneck=bottleneck,
         p_peak_used=dominant_p_peak,
         b_peak_used=b_peak,
+        clamped_by_overhead=clamped,
     )
 
 
@@ -350,6 +392,7 @@ __all__ = [
     "Bottleneck",
     "RooflineHardware",
     "RooflineResult",
+    "apply_launch_overhead",
     "compute_roofline",
     "compute_roofline_hybrid",
     "load_hardware",

--- a/tests/test_eval_roofline.py
+++ b/tests/test_eval_roofline.py
@@ -1,0 +1,135 @@
+"""Optional latency floors must agree across API and CLI calculation paths."""
+
+import importlib.util
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+import yaml
+
+from atrex_bench.eval.roofline import (
+    RooflineHardware,
+    compute_roofline,
+    compute_roofline_hybrid,
+    load_hardware,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = RooflineHardware("test", "test", "test", "test", {"bf16_tc": 1000}, 100, "")
+
+
+@pytest.mark.parametrize(
+    "w,q,theory", [(1, 0, 0.001), (0, 1, 0.01), (1, 1, 0.01), (100, 1, 0.1), (0, 0, 0)]
+)
+@pytest.mark.parametrize("floor", [None, 0.02, 0.01])
+@pytest.mark.parametrize("hybrid", [False, True])
+def test_floor_preserves_theory_and_empty_work(w, q, theory, floor, hybrid):
+    hw = replace(SPEC, launch_overhead_s=floor)
+    result = (
+        compute_roofline_hybrid({"bf16": w}, q, hw)
+        if hybrid
+        else compute_roofline(w, q, "bf16", hw)
+    )
+    expected = max(theory, floor or 0) if theory else 0
+    assert result.sol_time_s == pytest.approx(expected)
+    assert result.sol_time_ms == pytest.approx(expected * 1000)
+    assert result.clamped_by_overhead == bool(floor and 0 < theory < floor)
+    if w == 0:
+        assert result.bottleneck == ("memory" if q else "no_compute")
+
+
+@pytest.mark.parametrize(
+    "value", [0, -1, True, False, "3e-6", float("nan"), float("inf"), -float("inf")]
+)
+def test_invalid_floor_rejected_in_file_and_direct_api(tmp_path, value):
+    with pytest.raises(ValueError, match="launch_overhead_s"):
+        replace(SPEC, launch_overhead_s=value)
+    path = tmp_path / "test.yaml"
+    path.write_text(
+        yaml.safe_dump({"p_peak": SPEC.p_peak, "b_peak": {"hbm": 100}, "launch_overhead_s": value})
+    )
+    with pytest.raises(ValueError, match="launch_overhead_s"):
+        load_hardware(path)
+
+
+@pytest.mark.parametrize("config", [{}, {"launch_overhead_s": None}, {"launch_overhead_s": 0.02}])
+def test_load_optional_floor(tmp_path, config):
+    path = tmp_path / "test.yaml"
+    path.write_text(yaml.safe_dump({"p_peak": SPEC.p_peak, "b_peak": {"hbm": 100}, **config}))
+    assert load_hardware(path).launch_overhead_s == config.get("launch_overhead_s")
+
+
+@pytest.mark.parametrize("work", [{}, {"bf16": 0}, {"bf16": 1}, {"bf16": 1, "fp16": 1}])
+@pytest.mark.parametrize("q", [0, 1, 10])
+def test_cli_shape_calculation_and_floor_flag(work, q):
+    spec = importlib.util.spec_from_file_location("roofline_cli", ROOT / "scripts/roofline.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    hw = replace(SPEC, p_peak={"bf16_tc": 1000, "fp16_tc": 1000}, launch_overhead_s=0.02)
+    result, *_ = module._shape_compute(
+        shape_id="0",
+        shape_block={
+            "semantic_W_flops": work,
+            "semantic_Q_read_bytes": q,
+            "semantic_Q_write_bytes": 0,
+        },
+        hw=hw,
+        explicit_dtype=None,
+    )
+    theory = max(sum(work.values()) / 1000, q / 100)
+    assert result.sol_time_s == pytest.approx(max(theory, 0.02) if theory else 0)
+    assert module._result_to_payload(result)["clamped_by_overhead"] == (0 < theory < 0.02)
+
+
+def test_hybrid_sums_compute_before_applying_floor():
+    hw = replace(SPEC, p_peak={"bf16_tc": 1000, "fp16_tc": 2000}, launch_overhead_s=0.02)
+    result = compute_roofline_hybrid({"bf16": 10, "fp16": 40}, 1, hw)
+    assert result.sol_time_s == pytest.approx(0.03)
+    assert not result.clamped_by_overhead
+
+
+def test_cli_no_write_does_not_modify_cache(tmp_path, monkeypatch, capsys):
+    from scripts import roofline
+
+    op = tmp_path / "op"
+    op.mkdir()
+    cached = {
+        "shapes": {
+            "0": {
+                "semantic_W_flops": {},
+                "semantic_Q_read_bytes": 1,
+                "semantic_Q_write_bytes": 0,
+                "SOL_time_ms": {"test": 99},
+            }
+        }
+    }
+    path = op / "roofline.json"
+    path.write_text(json.dumps(cached))
+    hardware = tmp_path / "test.yaml"
+    hardware.write_text(
+        yaml.safe_dump(
+            {
+                "hardware": {"name": "test"},
+                "p_peak": SPEC.p_peak,
+                "b_peak": {"hbm": 100},
+                "launch_overhead_s": 0.02,
+            }
+        )
+    )
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "roofline",
+            "--operator",
+            str(op),
+            "--hardware",
+            str(hardware),
+            "--no-write",
+            "--format",
+            "json",
+        ],
+    )
+    assert roofline.main() == 0
+    assert json.loads(path.read_text()) == cached
+    assert '"clamped_by_overhead": true' in capsys.readouterr().out

--- a/tests/test_fused_moe_data.py
+++ b/tests/test_fused_moe_data.py
@@ -1,0 +1,48 @@
+"""Routing invariants for the public MoE input bundle (small CPU allocations)."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("top_k", [1, 2, 4])
+def test_fused_moe_routes_to_distinct_experts(monkeypatch, top_k):
+    spec = importlib.util.spec_from_file_location("moe_input", ROOT / "data/fused_moe/input.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    randn = torch.randn
+
+    def cpu_randn(*args, **kwargs):
+        kwargs["device"] = "cpu"
+        return randn(*args, **kwargs)
+
+    monkeypatch.setattr(torch, "randn", cpu_randn)
+    torch.manual_seed(0)
+    data = module._make_inputs(64, 4, 4, 4, top_k)
+    ids, weights = data["topk_ids"], data["topk_weights"]
+    assert ids.dtype == torch.int32
+    assert weights.dtype == torch.float32
+    assert ids.shape == weights.shape == (64, top_k)
+    assert (ids >= 0).all() and (ids < 4).all()
+    assert all(len(set(row.tolist())) == top_k for row in ids)
+    assert torch.isfinite(weights).all() and (weights >= 0).all()
+    torch.testing.assert_close(weights.sum(-1), torch.ones(64))
+
+
+def test_fused_moe_baselines_cover_shapes_without_private_fields():
+    root = ROOT / "data/fused_moe"
+    meta = json.loads((root / "metadata.json").read_text())
+    shapes = json.loads((root / "shapes.json").read_text())
+    assert meta["shapes"].keys() == shapes.keys()
+    assert len(shapes) == 23
+    for row in meta["shapes"].values():
+        baseline = row["production_performance"]["XPU-A"]
+        assert baseline["framework"] == "aiter"
+        assert baseline["performance_us"] > 0
+        assert not {"source_model", "source_trace", "trace_id"}.intersection(row)
+    assert meta["shapes"]["0"]["production_performance"]["XPU-A"]["performance_us"] == 232.72

--- a/tests/test_static_roofline_check.py
+++ b/tests/test_static_roofline_check.py
@@ -1,0 +1,36 @@
+"""Static cache validation must use the same floor and the matching device latency."""
+
+from dataclasses import replace
+
+import pytest
+
+from atrex_bench.eval.roofline import RooflineHardware
+from scripts import static_roofline_check as check
+
+
+@pytest.mark.parametrize("work", [{}, {"bf16": 0}, {"bf16": 1}])
+@pytest.mark.parametrize("q", [0, 1, 100])
+def test_static_floor_agrees_with_work(work, q):
+    hw = RooflineHardware("test", "test", "test", "test", {"bf16_tc": 1000}, 100, "")
+    block = {"semantic_W_flops": work, "semantic_Q_read_bytes": q, "semantic_Q_write_bytes": 0}
+    theory = check._compute_static_roofline(shape_id="x", shape_block=block, hw=hw)
+    result = check._compute_static_roofline(
+        shape_id="x", shape_block=block, hw=replace(hw, launch_overhead_s=0.02)
+    )
+    assert result.sol_time_s == (max(theory.sol_time_s, 0.02) if theory.sol_time_s else 0)
+
+
+def test_production_latency_never_falls_back_to_another_device():
+    meta = {
+        "shapes": {
+            "0": {
+                "production_performance": {
+                    "A": {"performance_us": 100},
+                    "B": {"performance_us": 200},
+                }
+            }
+        }
+    }
+    assert check._production_perf_us(meta, "0", "A") == 100
+    assert check._production_perf_us(meta, "0", "B") == 200
+    assert check._production_perf_us(meta, "0", "C") is None


### PR DESCRIPTION
## Overview

This PR aligns the public fused MoE input/baseline contract and restores an optional dispatch-latency floor for roofline SOL calculations. It also adds a static validator so cached SOL values can be checked without importing operator modules or running GPU kernels.

The changes are intentionally limited to the public core. Internal reporting, production adapters, private hardware profiles, and unredacted data are not included here.

## Why this is needed

### 1. Fused MoE input and baseline consistency

The previous public `fused_moe/input.py` generated `topk_ids` with independent `torch.randint` calls. That allowed the same token to select the same expert more than once, which is not representative of normal top-k router output. Duplicate routes can make sorted/scatter-style production kernels behave differently from the gather-based reference and can therefore create false correctness failures.

The public metadata also still contained the older SGLang performance baseline, while the corresponding production path and the maintained measurements use AITER. The input contract and the baseline therefore described different execution assumptions.

### 2. SOL values below dispatch latency

Pure roofline latency is computed as:

```text
max(sum(W[dtype] / P_peak[dtype]), Q / B_peak)
```

For very small kernels, that theoretical value can be lower than the measured kernel-dispatch latency of a device. The public implementation had no way to express that device-specific lower bound, even when a hardware profile had a measured value available. This could produce unrealistic sub-dispatch SOL values and make cached SOL values disagree with production-latency checks.

## What changed

### Fused MoE routing and public baselines

- Generate router logits over all experts and use `torch.topk` to select routes.
- Guarantee that every token selects `top_k` distinct experts.
- Normalize the selected weights and preserve the public `float32`/`int32` contract.
- Update all 23 public XPU-A fused MoE baseline entries to the recorded AITER measurements.
- Preserve the rest of each public shape metadata object; no private trace/model provenance is introduced.

These baseline numbers are migrated recorded measurements. This PR did **not** re-run the production benchmark on a GPU.

### Optional launch-overhead floor

- Add optional `launch_overhead_s` support to `RooflineHardware`.
- Accept a missing value or `null` as “no floor,” preserving current behavior.
- Reject booleans, strings, zero/negative values, NaN, and infinities.
- Apply the floor consistently to:
  - single-dtype roofline calculations;
  - hybrid/multi-dtype calculations;
  - integer/memory-only operator calculations in the CLI.
- Keep an empty workload (`W == 0` and `Q == 0`) at zero.
- Add `clamped_by_overhead` to `RooflineResult` and JSON output.
- Label clamped values in text output so a launch floor is not mistaken for a pure theoretical roofline bound.

No device-specific floor is hardcoded in the implementation. A floor is active only when the selected hardware profile explicitly provides one.

### Static SOL validation

Add `scripts/static_roofline_check.py`, which performs read-only checks without loading `input.py`/`reference.py` or executing kernels:

- recomputes cached `SOL_time_ms` from semantic W/Q fields and hardware YAML;
- uses the same optional launch-overhead semantics as the Python API and roofline CLI;
- reports missing/invalid hardware mappings and W/Q inconsistencies;
- compares `T_SOL / TProd` only when the production baseline belongs to the same hardware key, avoiding cross-device comparisons;
- supports operator filters, explicit latency hardware, JSON/text output, configurable tolerances, and `--warnings-as-errors`.

### Documentation

`docs/roofline_semantics.md` documents:

- the theoretical SOL formula;
- the distinction between empty work and memory-only work;
- the optional dispatch floor and `clamped_by_overhead` flag;
- cache review with `--no-write` before explicit recomputation;
- the requirement to validate timing-mode compatibility, especially before applying an eager-dispatch floor to CUDA Graph replay;
- the provenance limitation of the migrated fused MoE baseline.

## Compatibility and migration behavior

- Hardware profiles without `launch_overhead_s`, or with `launch_overhead_s: null`, retain the previous theoretical result.
- The new dataclass fields have defaults, so existing constructors remain compatible.
- Existing cached `SOL_time_ms` values are **not** rewritten automatically by this PR.
- Bottleneck classification, arithmetic intensity, and roofline throughput continue to describe the theoretical model; only the reported latency may be raised by the explicit dispatch floor.
- JSON output gains the additive `clamped_by_overhead` field.

## Validation

Local CPU validation on the PR commit:

```text
Full test suite:       547 passed, 8 skipped
Focused new contracts: 69 passed
Static public-data SOL check: 0 errors, 0 warnings
```

The focused coverage includes:

- unique MoE routes for `top_k` values 1, 2, and 4;
- normalized route weights and expected dtypes;
- coverage of all 23 fused MoE shapes and absence of private provenance fields;
- single-dtype, hybrid, memory-only, and empty-work SOL paths;
- missing/null/valid/invalid launch-overhead values;
- CLI/API/static-check consistency and no-write cache behavior;
- exact hardware matching for production-latency comparisons.

GitHub CodeQL checks and the CLA check are currently passing.

## Not covered by this PR

- No new GPU performance measurement was performed.
- No public hardware profile is assigned a new launch-overhead value here.
- No existing SOL cache is bulk-refreshed.
- Internal reporting, private production reproduction tooling, private hardware specifications, and Aone CI changes remain in the internal extension repository.

## Suggested review order

1. `data/fused_moe/input.py` and `data/fused_moe/metadata.json` for the input/baseline contract.
2. `src/atrex_bench/eval/roofline.py` for API semantics and backward compatibility.
3. `scripts/roofline.py` and `scripts/static_roofline_check.py` for CLI consistency and failure policy.
4. The three new test modules and `docs/roofline_semantics.md` for edge cases and documented limitations.
