### PR TITLE
fix(eval): validate None returns and input mutations

### DIFF
--- a/docs/none-mutation-correctness.md
+++ b/docs/none-mutation-correctness.md
@@ -13,7 +13,8 @@ adjacent `metadata.json`:
 The evaluator binds actual supplied arguments to `Model.forward`, runs reference
 and candidate on independent clones, and checks:
 
-- exact return container/scalar types, tensor shapes and dtypes, and values;
+- exact return container/scalar types and tensor dtypes when `mutates_inputs`
+  is explicitly present (including an empty list), plus shapes and values;
 - every element of each declared mutable input, not just an active prefix;
 - undeclared inputs on both sides against their original backing bytes,
   including unused storage tails, with no numerical tolerance;
@@ -24,6 +25,14 @@ each correctness case. The latter includes successful unchanged-input checks as
 well as failures. Unknown mutation names fail before invocation. A missing
 mutation declaration means no supplied input may change.
 
+Mutation declarations are storage-wide for unchanged-input checks. If `out` and
+an undeclared input `x` share storage, writing even a disjoint `out` region changes
+`x`'s backing bytes and fails the check. Declare every supplied alias whose
+backing storage is written as mutable, or supply independent storage if the ABI
+requires `x` to remain immutable. Declared mutable inputs are compared element by
+element over their logical views; declaring an alias does not certify bytes
+outside the union of those views.
+
 ## Scope and compatibility
 
 CUDA Graph replay's separate output-only checker has not been extended to
@@ -33,5 +42,8 @@ state are not covered by the strided-input validation.
 
 Strided input clones now preserve internally overlapping strides instead of
 densifying them. This intentionally changes the previous overlap-cloning
-contract. Scalar return types and values, tensor dtypes, and tuple versus list
-returns are also checked strictly.
+contract. Benchmarks without an explicit `mutates_inputs` field retain legacy
+tuple/list, numeric scalar and tensor dtype comparison behavior. Explicit
+mutation contracts require exact container/scalar types and tensor dtypes;
+floating-point values still use the configured numerical tolerances. `None`
+must match `None` in both modes, including nested leaves.

--- a/docs/none-mutation-correctness.md
+++ b/docs/none-mutation-correctness.md
@@ -1,0 +1,37 @@
+# None-returning and mutating callables
+
+Eager correctness verification accepts `None` without wrapping the return value
+or changing the operator's arguments.
+
+Declare the supplied input names written by the callable in the reference's
+adjacent `metadata.json`:
+
+```json
+{"benchmark_contract": {"mutates_inputs": ["out", "residual"]}}
+```
+
+The evaluator binds actual supplied arguments to `Model.forward`, runs reference
+and candidate on independent clones, and checks:
+
+- exact return container/scalar types, tensor shapes and dtypes, and values;
+- every element of each declared mutable input, not just an active prefix;
+- undeclared inputs on both sides against their original backing bytes,
+  including unused storage tails, with no numerical tolerance;
+- cloned strided storage offsets and aliases shared across supplied inputs.
+
+Receipts retain `outputs` and add `mutated_inputs` and `unexpected_mutations` to
+each correctness case. The latter includes successful unchanged-input checks as
+well as failures. Unknown mutation names fail before invocation. A missing
+mutation declaration means no supplied input may change.
+
+## Scope and compatibility
+
+CUDA Graph replay's separate output-only checker has not been extended to
+certify mutable state. An eager receipt does not certify graph replay or live
+service replacement. Cross-device transfers and arbitrary sparse/nested input
+state are not covered by the strided-input validation.
+
+Strided input clones now preserve internally overlapping strides instead of
+densifying them. This intentionally changes the previous overlap-cloning
+contract. Scalar return types and values, tensor dtypes, and tuple versus list
+returns are also checked strictly.

--- a/src/atrex_bench/cli/run_eval.py
+++ b/src/atrex_bench/cli/run_eval.py
@@ -1388,9 +1388,10 @@ def _correctness_from_payload(payload: dict[str, object]) -> CorrectnessShapeRes
     cases: list[CorrectnessCase] = []
     for raw_case in payload.get("cases") or []:
         case_values = dict(raw_case)
-        case_values["outputs"] = [
-            OutputDiff(**raw_output) for raw_output in (raw_case.get("outputs") or [])
-        ]
+        for field_name in ("outputs", "mutated_inputs", "unexpected_mutations"):
+            case_values[field_name] = [
+                OutputDiff(**raw_output) for raw_output in (raw_case.get(field_name) or [])
+            ]
         cases.append(CorrectnessCase(**case_values))
     values = dict(payload)
     # Keep indexing ``status``: a payload without it is malformed, and KeyError

--- a/src/atrex_bench/eval/_runtime.py
+++ b/src/atrex_bench/eval/_runtime.py
@@ -521,12 +521,14 @@ def _has_non_overlapping_strides(tensor: torch.Tensor) -> bool:
     return True
 
 
-def clone_value(value: Any) -> Any:
-    """Recursively clone tensors while preserving the overall structure."""
+def clone_value(value: Any, _storages: dict | None = None) -> Any:
+    """Clone a call tree, preserving strided storage offsets and input aliases."""
+    if _storages is None:
+        _storages = {}
     if isinstance(value, ModelInputs):
         return ModelInputs(
-            args=clone_value(value.args),
-            kwargs=clone_value(value.kwargs),
+            args=clone_value(value.args, _storages),
+            kwargs=clone_value(value.kwargs, _storages),
         )
     if isinstance(value, torch.Tensor):
         detached = value.detach()
@@ -535,31 +537,28 @@ def clone_value(value: Any) -> Any:
             and not detached.is_quantized
             and not detached.is_nested
         ):
-            if not _has_non_overlapping_strides(detached):
-                return detached.clone()
-            clone = torch.empty_strided(
-                tuple(detached.shape),
-                tuple(detached.stride()),
-                dtype=detached.dtype,
-                device=detached.device,
+            storage = detached.untyped_storage()
+            key = (detached.device, storage._cdata)
+            if key not in _storages:
+                raw = torch.empty(0, dtype=torch.uint8, device=detached.device)
+                raw = raw.set_(storage, 0, (storage.nbytes(),), (1,)).clone()
+                _storages[key] = raw.untyped_storage()
+            return torch.empty(0, dtype=detached.dtype, device=detached.device).set_(
+                _storages[key], detached.storage_offset(), detached.shape, detached.stride()
             )
-            return clone.copy_(detached)
         return detached.clone()
     if isinstance(value, list):
-        return [clone_value(item) for item in value]
+        return [clone_value(item, _storages) for item in value]
     if isinstance(value, tuple):
-        return tuple(clone_value(item) for item in value)
+        return tuple(clone_value(item, _storages) for item in value)
     if isinstance(value, dict):
-        return {key: clone_value(item) for key, item in value.items()}
+        return {key: clone_value(item, _storages) for key, item in value.items()}
     return copy.deepcopy(value)
 
 
 def clone_model_inputs(inputs: ModelInputs) -> ModelInputs:
     """Clone a ModelInputs payload for a fresh model invocation."""
-    return ModelInputs(
-        args=tuple(clone_value(item) for item in inputs.args),
-        kwargs={key: clone_value(item) for key, item in inputs.kwargs.items()},
-    )
+    return clone_value(inputs)
 
 
 def summarize_value(value: Any) -> Any:
@@ -624,13 +623,7 @@ def infer_operator_id(reference_path: Path) -> str:
 def prepare_model_inputs(raw_inputs: Any, device: torch.device) -> ModelInputs:
     """Normalize, clone, and move model inputs to the evaluation device."""
     normalized_inputs = normalize_model_inputs(raw_inputs)
-    return ModelInputs(
-        args=tuple(move_to_device(clone_value(item), device) for item in normalized_inputs.args),
-        kwargs={
-            key: move_to_device(clone_value(item), device)
-            for key, item in normalized_inputs.kwargs.items()
-        },
-    )
+    return move_to_device(clone_model_inputs(normalized_inputs), device)
 
 
 def load_model_inputs(module: ModuleType, device: torch.device) -> ModelInputs:

--- a/src/atrex_bench/eval/correctness.py
+++ b/src/atrex_bench/eval/correctness.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import inspect
+import json
 import traceback
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -64,6 +66,8 @@ class CorrectnessCase:
 
     input_artifact: dict[str, str] | None
     outputs: list[OutputDiff] = field(default_factory=list)
+    mutated_inputs: list[OutputDiff] = field(default_factory=list)
+    unexpected_mutations: list[OutputDiff] = field(default_factory=list)
     error: str | None = None
 
 
@@ -86,7 +90,7 @@ class CorrectnessShapeResult:
 
 def _is_leaf_output(value: object) -> bool:
     """Return whether a value is a leaf in the output tree (tensor or numeric scalar)."""
-    return isinstance(value, (torch.Tensor, bool, int, float))
+    return value is None or isinstance(value, (torch.Tensor, bool, int, float))
 
 
 def _describe_output_structure(value: object) -> str:
@@ -109,6 +113,8 @@ def _validate_output_structures_match(
     path: str = "output",
 ) -> None:
     """Raise ValueError if reference / candidate output structures don't match."""
+    if type(reference) is not type(candidate):
+        raise ValueError(f"Output structure mismatch at {path}: reference={type(reference).__name__}, candidate={type(candidate).__name__}")
     ref_is_dict = isinstance(reference, dict)
     cand_is_dict = isinstance(candidate, dict)
     if ref_is_dict != cand_is_dict:
@@ -208,6 +214,8 @@ def _compare_output_tensors(
     max_rel_l2: float | None = None,
 ) -> OutputDiff:
     """Compare a pair of output tensors and return the per-output diff record."""
+    if reference_tensor.dtype != candidate_tensor.dtype:
+        return OutputDiff(name=name, passed=False, error=f"Output dtype mismatch: {reference_tensor.dtype} != {candidate_tensor.dtype}")
     if reference_tensor.shape != candidate_tensor.shape:
         return OutputDiff(
             name=name,
@@ -282,6 +290,56 @@ def _compare_output_tensors(
     )
 
 
+def _compare_value_trees(reference, candidate, *, name, atol, rtol, max_rel_l2=None):
+    """Compare exact return structure and every value, including None leaves."""
+    try:
+        _validate_output_structures_match(reference, candidate, path=name)
+    except ValueError as error:
+        return [OutputDiff(name=name, passed=False, error=str(error))]
+    if isinstance(reference, dict):
+        return [diff for key in reference for diff in _compare_value_trees(
+            reference[key], candidate[key], name=f"{name}.{key}",
+            atol=atol, rtol=rtol, max_rel_l2=max_rel_l2)]
+    if isinstance(reference, (list, tuple)):
+        return [diff for index, (left, right) in enumerate(zip(reference, candidate))
+                for diff in _compare_value_trees(left, right, name=f"{name}[{index}]",
+                    atol=atol, rtol=rtol, max_rel_l2=max_rel_l2)]
+    if isinstance(reference, torch.Tensor):
+        return [_compare_output_tensors(reference, candidate, name=name,
+            atol=atol, rtol=rtol, max_rel_l2=max_rel_l2)]
+    return [OutputDiff(name=name, passed=reference == candidate,
+        error=None if reference == candidate else "Scalar value mismatch")]
+
+
+def _check_unchanged(before, after, *, name):
+    """Check full backing bytes (including pool tails) without float tolerances."""
+    if type(before) is not type(after):
+        return [OutputDiff(name=name, passed=False, error="Input type changed")]
+    if isinstance(before, torch.Tensor):
+        same = (before.dtype == after.dtype and before.shape == after.shape
+                and before.stride() == after.stride()
+                and before.storage_offset() == after.storage_offset())
+        def raw(tensor):
+            storage = tensor.untyped_storage()
+            return torch.empty(0, dtype=torch.uint8, device=tensor.device).set_(
+                storage, 0, (storage.nbytes(),), (1,))
+        same = same and torch.equal(raw(before), raw(after))
+        return [OutputDiff(name=name, passed=bool(same),
+            error=None if same else "Undeclared input mutation")]
+    if isinstance(before, dict):
+        if before.keys() != after.keys():
+            return [OutputDiff(name=name, passed=False, error="Input keys changed")]
+        return [diff for key in before for diff in _check_unchanged(
+            before[key], after[key], name=f"{name}.{key}")]
+    if isinstance(before, (tuple, list)):
+        if len(before) != len(after):
+            return [OutputDiff(name=name, passed=False, error="Input length changed")]
+        return [diff for index, (left, right) in enumerate(zip(before, after))
+                for diff in _check_unchanged(left, right, name=f"{name}[{index}]")]
+    same = before == after
+    return [OutputDiff(name=name, passed=bool(same), error=None if same else "Input value changed")]
+
+
 def check_correctness(
     reference_path: Path,
     candidate_path: Path,
@@ -329,6 +387,12 @@ def check_correctness(
             shape = load_shape_spec(reference_path, shape_id)
         else:
             shape = None
+        metadata_path = reference_path.parent / "metadata.json"
+        metadata = json.loads(metadata_path.read_text()) if metadata_path.is_file() else {}
+        mutations = metadata.get("benchmark_contract", {}).get("mutates_inputs", [])
+        if not isinstance(mutations, list) or not all(isinstance(x, str) for x in mutations):
+            raise ValueError("benchmark_contract.mutates_inputs must be a list of input names")
+        signature = inspect.signature(loaded_models.reference_model.forward)
     except Exception:
         return CorrectnessShapeResult(
             status="failed",
@@ -388,6 +452,11 @@ def check_correctness(
         try:
             reference_call_inputs = clone_model_inputs(inputs)
             candidate_call_inputs = clone_model_inputs(inputs)
+            def named(call):
+                return signature.bind(*call.args, **call.kwargs).arguments
+            original_named = named(inputs)
+            if set(mutations) - original_named.keys():
+                raise ValueError(f"Unknown mutated input names: {set(mutations) - original_named.keys()}")
             with torch.inference_mode():
                 # Reference is the golden implementation; we trust it and
                 # never time it out. The candidate is the AI-generated code
@@ -446,48 +515,26 @@ def check_correctness(
                 _abort_remaining_cases(case_index, "output structure mismatch")
                 break
 
-            reference_outputs = flatten_outputs(reference_output)
-            candidate_outputs = flatten_outputs(candidate_output)
-
-            if len(reference_outputs) != len(candidate_outputs):
-                failed_cases += 1
-                case_records.append(
-                    CorrectnessCase(
-                        input_artifact=artifact,
-                        error=(
-                            "Output count mismatch: "
-                            f"reference={len(reference_outputs)}, "
-                            f"candidate={len(candidate_outputs)}"
-                        ),
-                    )
-                )
-                _abort_remaining_cases(case_index, "output count mismatch")
-                break
-
-            output_diffs: list[OutputDiff] = []
-            case_passed = True
-            has_structural_failure = False
-            for (raw_name, reference_tensor), (_, candidate_tensor) in zip(
-                reference_outputs,
-                candidate_outputs,
-            ):
-                output_diff = _compare_output_tensors(
-                    reference_tensor,
-                    candidate_tensor,
-                    name=_flatten_output_name(raw_name),
-                    atol=atol,
-                    rtol=rtol,
-                    max_rel_l2=effective_max_rel_l2,
-                )
-                output_diffs.append(output_diff)
-                if not output_diff.passed:
-                    case_passed = False
-                # error != None means this is a structural failure (shape
-                # mismatch, compare-time exception) rather than an atol/rtol
-                # diff. Structural failures are deterministic, so we treat
-                # them like the other non-accuracy failures and early-abort.
-                if output_diff.error is not None:
-                    has_structural_failure = True
+            output_diffs = _compare_value_trees(reference_output, candidate_output,
+                name="output", atol=atol, rtol=rtol, max_rel_l2=effective_max_rel_l2)
+            output_diffs = [OutputDiff(**{**diff.__dict__, "name": _flatten_output_name(diff.name)})
+                            for diff in output_diffs]
+            reference_named = named(reference_call_inputs)
+            candidate_named = named(candidate_call_inputs)
+            mutation_diffs = []
+            unexpected_diffs = []
+            for key, before in original_named.items():
+                if key in mutations:
+                    mutation_diffs.extend(_compare_value_trees(reference_named[key],
+                        candidate_named[key], name=f"input.{key}", atol=atol, rtol=rtol,
+                        max_rel_l2=effective_max_rel_l2))
+                else:
+                    for role, state in (("reference", reference_named), ("candidate", candidate_named)):
+                        unexpected_diffs.extend(_check_unchanged(before, state[key],
+                            name=f"{role}.input.{key}"))
+            all_diffs = output_diffs + mutation_diffs + unexpected_diffs
+            case_passed = all(diff.passed for diff in all_diffs)
+            has_structural_failure = any(diff.error is not None for diff in all_diffs)
 
             if not case_passed:
                 failed_cases += 1
@@ -496,6 +543,8 @@ def check_correctness(
                 CorrectnessCase(
                     input_artifact=artifact,
                     outputs=output_diffs,
+                    mutated_inputs=mutation_diffs,
+                    unexpected_mutations=unexpected_diffs,
                 )
             )
 

--- a/src/atrex_bench/eval/correctness.py
+++ b/src/atrex_bench/eval/correctness.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import os
 import inspect
 import json
+import os
 import traceback
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 import torch
@@ -111,10 +111,16 @@ def _validate_output_structures_match(
     candidate: object,
     *,
     path: str = "output",
+    strict_types: bool = False,
 ) -> None:
     """Raise ValueError if reference / candidate output structures don't match."""
-    if type(reference) is not type(candidate):
-        raise ValueError(f"Output structure mismatch at {path}: reference={type(reference).__name__}, candidate={type(candidate).__name__}")
+    if (strict_types and type(reference) is not type(candidate)) or (
+        (reference is None) != (candidate is None)
+    ):
+        raise ValueError(
+            f"Output structure mismatch at {path}: reference={type(reference).__name__}, "
+            f"candidate={type(candidate).__name__}"
+        )
     ref_is_dict = isinstance(reference, dict)
     cand_is_dict = isinstance(candidate, dict)
     if ref_is_dict != cand_is_dict:
@@ -140,7 +146,7 @@ def _validate_output_structures_match(
             )
         for key in sorted(ref_keys):
             _validate_output_structures_match(
-                reference[key], candidate[key], path=f"{path}.{key}"
+                reference[key], candidate[key], path=f"{path}.{key}", strict_types=strict_types
             )
         return
 
@@ -160,7 +166,7 @@ def _validate_output_structures_match(
             )
         for index, (ref_item, cand_item) in enumerate(zip(reference, candidate)):
             _validate_output_structures_match(
-                ref_item, cand_item, path=f"{path}[{index}]"
+                ref_item, cand_item, path=f"{path}[{index}]", strict_types=strict_types
             )
         return
 
@@ -212,10 +218,15 @@ def _compare_output_tensors(
     atol: float,
     rtol: float,
     max_rel_l2: float | None = None,
+    strict_dtype: bool = False,
 ) -> OutputDiff:
     """Compare a pair of output tensors and return the per-output diff record."""
-    if reference_tensor.dtype != candidate_tensor.dtype:
-        return OutputDiff(name=name, passed=False, error=f"Output dtype mismatch: {reference_tensor.dtype} != {candidate_tensor.dtype}")
+    if strict_dtype and reference_tensor.dtype != candidate_tensor.dtype:
+        return OutputDiff(
+            name=name,
+            passed=False,
+            error=f"Output dtype mismatch: {reference_tensor.dtype} != {candidate_tensor.dtype}",
+        )
     if reference_tensor.shape != candidate_tensor.shape:
         return OutputDiff(
             name=name,
@@ -290,25 +301,61 @@ def _compare_output_tensors(
     )
 
 
-def _compare_value_trees(reference, candidate, *, name, atol, rtol, max_rel_l2=None):
-    """Compare exact return structure and every value, including None leaves."""
+def _compare_value_trees(
+    reference, candidate, *, name, atol, rtol, max_rel_l2=None, strict_types=False
+):
+    """Compare return values, with exact types for explicit mutation contracts."""
     try:
-        _validate_output_structures_match(reference, candidate, path=name)
+        _validate_output_structures_match(
+            reference, candidate, path=name, strict_types=strict_types
+        )
     except ValueError as error:
         return [OutputDiff(name=name, passed=False, error=str(error))]
     if isinstance(reference, dict):
-        return [diff for key in reference for diff in _compare_value_trees(
-            reference[key], candidate[key], name=f"{name}.{key}",
-            atol=atol, rtol=rtol, max_rel_l2=max_rel_l2)]
+        return [
+            diff
+            for key in reference
+            for diff in _compare_value_trees(
+                reference[key],
+                candidate[key],
+                name=f"{name}.{key}",
+                atol=atol,
+                rtol=rtol,
+                max_rel_l2=max_rel_l2,
+                strict_types=strict_types,
+            )
+        ]
     if isinstance(reference, (list, tuple)):
-        return [diff for index, (left, right) in enumerate(zip(reference, candidate))
-                for diff in _compare_value_trees(left, right, name=f"{name}[{index}]",
-                    atol=atol, rtol=rtol, max_rel_l2=max_rel_l2)]
-    if isinstance(reference, torch.Tensor):
-        return [_compare_output_tensors(reference, candidate, name=name,
-            atol=atol, rtol=rtol, max_rel_l2=max_rel_l2)]
-    return [OutputDiff(name=name, passed=reference == candidate,
-        error=None if reference == candidate else "Scalar value mismatch")]
+        return [
+            diff
+            for index, (left, right) in enumerate(zip(reference, candidate))
+            for diff in _compare_value_trees(
+                left,
+                right,
+                name=f"{name}[{index}]",
+                atol=atol,
+                rtol=rtol,
+                max_rel_l2=max_rel_l2,
+                strict_types=strict_types,
+            )
+        ]
+    if reference is None:
+        return [OutputDiff(name=name, passed=True)]
+    # Retain legacy scalar conversion and tolerance semantics as well as
+    # list/tuple interoperability for benchmarks without an explicit contract.
+    reference_tensor = flatten_outputs(reference)[0][1]
+    candidate_tensor = flatten_outputs(candidate)[0][1]
+    return [
+        _compare_output_tensors(
+            reference_tensor,
+            candidate_tensor,
+            name=name,
+            atol=atol,
+            rtol=rtol,
+            max_rel_l2=max_rel_l2,
+            strict_dtype=strict_types,
+        )
+    ]
 
 
 def _check_unchanged(before, after, *, name):
@@ -316,26 +363,41 @@ def _check_unchanged(before, after, *, name):
     if type(before) is not type(after):
         return [OutputDiff(name=name, passed=False, error="Input type changed")]
     if isinstance(before, torch.Tensor):
-        same = (before.dtype == after.dtype and before.shape == after.shape
-                and before.stride() == after.stride()
-                and before.storage_offset() == after.storage_offset())
+        same = (
+            before.dtype == after.dtype
+            and before.shape == after.shape
+            and before.stride() == after.stride()
+            and before.storage_offset() == after.storage_offset()
+        )
+
         def raw(tensor):
             storage = tensor.untyped_storage()
             return torch.empty(0, dtype=torch.uint8, device=tensor.device).set_(
-                storage, 0, (storage.nbytes(),), (1,))
+                storage, 0, (storage.nbytes(),), (1,)
+            )
+
         same = same and torch.equal(raw(before), raw(after))
-        return [OutputDiff(name=name, passed=bool(same),
-            error=None if same else "Undeclared input mutation")]
+        return [
+            OutputDiff(
+                name=name, passed=bool(same), error=None if same else "Undeclared input mutation"
+            )
+        ]
     if isinstance(before, dict):
         if before.keys() != after.keys():
             return [OutputDiff(name=name, passed=False, error="Input keys changed")]
-        return [diff for key in before for diff in _check_unchanged(
-            before[key], after[key], name=f"{name}.{key}")]
+        return [
+            diff
+            for key in before
+            for diff in _check_unchanged(before[key], after[key], name=f"{name}.{key}")
+        ]
     if isinstance(before, (tuple, list)):
         if len(before) != len(after):
             return [OutputDiff(name=name, passed=False, error="Input length changed")]
-        return [diff for index, (left, right) in enumerate(zip(before, after))
-                for diff in _check_unchanged(left, right, name=f"{name}[{index}]")]
+        return [
+            diff
+            for index, (left, right) in enumerate(zip(before, after))
+            for diff in _check_unchanged(left, right, name=f"{name}[{index}]")
+        ]
     same = before == after
     return [OutputDiff(name=name, passed=bool(same), error=None if same else "Input value changed")]
 
@@ -389,7 +451,9 @@ def check_correctness(
             shape = None
         metadata_path = reference_path.parent / "metadata.json"
         metadata = json.loads(metadata_path.read_text()) if metadata_path.is_file() else {}
-        mutations = metadata.get("benchmark_contract", {}).get("mutates_inputs", [])
+        contract = metadata.get("benchmark_contract", {})
+        mutations = contract.get("mutates_inputs", [])
+        strict_types = "mutates_inputs" in contract
         if not isinstance(mutations, list) or not all(isinstance(x, str) for x in mutations):
             raise ValueError("benchmark_contract.mutates_inputs must be a list of input names")
         signature = inspect.signature(loaded_models.reference_model.forward)
@@ -429,14 +493,9 @@ def check_correctness(
         if skipped <= 0:
             return
         failed_cases += skipped
-        reason = (
-            f"skipped after case {after_case_index} failed deterministically: "
-            f"{short_reason}"
-        )
+        reason = f"skipped after case {after_case_index} failed deterministically: {short_reason}"
         for _ in range(skipped):
-            case_records.append(
-                CorrectnessCase(input_artifact=None, error=reason)
-            )
+            case_records.append(CorrectnessCase(input_artifact=None, error=reason))
 
     for case_index in range(num_correctness_cases):
         # Seed every RNG just before generating inputs so the random tensors
@@ -452,11 +511,15 @@ def check_correctness(
         try:
             reference_call_inputs = clone_model_inputs(inputs)
             candidate_call_inputs = clone_model_inputs(inputs)
+
             def named(call):
                 return signature.bind(*call.args, **call.kwargs).arguments
+
             original_named = named(inputs)
             if set(mutations) - original_named.keys():
-                raise ValueError(f"Unknown mutated input names: {set(mutations) - original_named.keys()}")
+                raise ValueError(
+                    f"Unknown mutated input names: {set(mutations) - original_named.keys()}"
+                )
             with torch.inference_mode():
                 # Reference is the golden implementation; we trust it and
                 # never time it out. The candidate is the AI-generated code
@@ -482,9 +545,7 @@ def check_correctness(
                             error=str(timeout_error),
                         )
                     )
-                    _abort_remaining_cases(
-                        case_index, f"{candidate_timeout_s}s timeout"
-                    )
+                    _abort_remaining_cases(case_index, f"{candidate_timeout_s}s timeout")
                     break
                 if untrusted_mode:
                     try:
@@ -497,13 +558,13 @@ def check_correctness(
                                 error=str(reward_hack),
                             )
                         )
-                        _abort_remaining_cases(
-                            case_index, "untrusted output guard failed"
-                        )
+                        _abort_remaining_cases(case_index, "untrusted output guard failed")
                         break
 
             try:
-                _validate_output_structures_match(reference_output, candidate_output)
+                _validate_output_structures_match(
+                    reference_output, candidate_output, strict_types=strict_types
+                )
             except ValueError as structure_error:
                 failed_cases += 1
                 case_records.append(
@@ -515,23 +576,43 @@ def check_correctness(
                 _abort_remaining_cases(case_index, "output structure mismatch")
                 break
 
-            output_diffs = _compare_value_trees(reference_output, candidate_output,
-                name="output", atol=atol, rtol=rtol, max_rel_l2=effective_max_rel_l2)
-            output_diffs = [OutputDiff(**{**diff.__dict__, "name": _flatten_output_name(diff.name)})
-                            for diff in output_diffs]
+            output_diffs = _compare_value_trees(
+                reference_output,
+                candidate_output,
+                name="output",
+                atol=atol,
+                rtol=rtol,
+                max_rel_l2=effective_max_rel_l2,
+                strict_types=strict_types,
+            )
+            output_diffs = [
+                replace(diff, name=_flatten_output_name(diff.name)) for diff in output_diffs
+            ]
             reference_named = named(reference_call_inputs)
             candidate_named = named(candidate_call_inputs)
             mutation_diffs = []
             unexpected_diffs = []
             for key, before in original_named.items():
                 if key in mutations:
-                    mutation_diffs.extend(_compare_value_trees(reference_named[key],
-                        candidate_named[key], name=f"input.{key}", atol=atol, rtol=rtol,
-                        max_rel_l2=effective_max_rel_l2))
+                    mutation_diffs.extend(
+                        _compare_value_trees(
+                            reference_named[key],
+                            candidate_named[key],
+                            name=f"input.{key}",
+                            atol=atol,
+                            rtol=rtol,
+                            max_rel_l2=effective_max_rel_l2,
+                            strict_types=True,
+                        )
+                    )
                 else:
-                    for role, state in (("reference", reference_named), ("candidate", candidate_named)):
-                        unexpected_diffs.extend(_check_unchanged(before, state[key],
-                            name=f"{role}.input.{key}"))
+                    for role, state in (
+                        ("reference", reference_named),
+                        ("candidate", candidate_named),
+                    ):
+                        unexpected_diffs.extend(
+                            _check_unchanged(before, state[key], name=f"{role}.input.{key}")
+                        )
             all_diffs = output_diffs + mutation_diffs + unexpected_diffs
             case_passed = all(diff.passed for diff in all_diffs)
             has_structural_failure = any(diff.error is not None for diff in all_diffs)
@@ -549,9 +630,7 @@ def check_correctness(
             )
 
             if has_structural_failure:
-                _abort_remaining_cases(
-                    case_index, "per-tensor shape/structural mismatch"
-                )
+                _abort_remaining_cases(case_index, "per-tensor shape/structural mismatch")
                 break
         except Exception:
             # Any other exception in the case body (e.g. candidate raised an
@@ -566,9 +645,7 @@ def check_correctness(
                     error=tb,
                 )
             )
-            _abort_remaining_cases(
-                case_index, "candidate raised exception"
-            )
+            _abort_remaining_cases(case_index, "candidate raised exception")
             break
 
     if failed_cases == 0:

--- a/tests/test_eval_runtime.py
+++ b/tests/test_eval_runtime.py
@@ -34,15 +34,18 @@ def test_clone_value_keeps_expanded_tensor_values_without_aliasing() -> None:
     assert torch.equal(cloned, source)
 
 
-def test_clone_value_densifies_internally_overlapped_strided_tensor() -> None:
+def test_clone_value_preserves_internally_overlapped_strided_tensor() -> None:
     source = torch.arange(4).as_strided((2, 2), (1, 1))
 
     cloned = runtime_module.clone_value(source)
 
     assert cloned is not source
     assert cloned.untyped_storage().data_ptr() != source.untyped_storage().data_ptr()
-    assert cloned.stride() != source.stride()
+    assert cloned.stride() == source.stride()
     assert torch.equal(cloned, source)
+    cloned[0, 1] = 42
+    assert cloned[1, 0].item() == 42
+    assert source[0, 1].item() == 1
 
 
 def test_clone_value_keeps_sparse_tensor_clone_support() -> None:

--- a/tests/test_none_mutation_contract.py
+++ b/tests/test_none_mutation_contract.py
@@ -1,0 +1,199 @@
+"""Regression coverage for eager None, mutation and legacy output contracts."""
+
+import json
+
+import pytest
+import torch
+
+from atrex_bench.cli.run_eval import _correctness_from_payload, _correctness_to_payload
+from atrex_bench.eval._runtime import ModelInputs, clone_model_inputs
+from atrex_bench.eval.correctness import (
+    _check_unchanged,
+    _compare_value_trees,
+    check_correctness,
+)
+
+
+def evaluate(
+    tmp_path,
+    candidate,
+    *,
+    reference="out.copy_(x + 1); return None",
+    mutations=("out",),
+    inputs="[torch.arange(8.), torch.zeros(8)]",
+):
+    common = "import torch\nclass Model(torch.nn.Module):\n    def forward(self, x, out):\n        "
+    (tmp_path / "reference.py").write_text(
+        common
+        + reference
+        + "\n\ndef get_inputs():\n    return "
+        + inputs
+        + "\n\ndef get_init_inputs():\n    return []\n"
+    )
+    (tmp_path / "solution.py").write_text(common + candidate + "\n")
+    metadata = (
+        {} if mutations is None else {"benchmark_contract": {"mutates_inputs": list(mutations)}}
+    )
+    (tmp_path / "metadata.json").write_text(json.dumps(metadata))
+    return check_correctness(tmp_path / "reference.py", tmp_path / "solution.py", device="cpu")
+
+
+def test_none_inplace_pass(tmp_path):
+    result = evaluate(tmp_path, "out.copy_(x + 1); return None")
+    assert result.status == "passed", result.reason
+    case = result.cases[0]
+    assert case.outputs[0].name == "out"
+    assert case.outputs[0].passed
+    assert case.mutated_inputs[0].name == "input.out"
+    assert all(diff.passed for diff in case.mutated_inputs + case.unexpected_mutations)
+
+
+def test_mutation_diagnostics_survive_json_worker_round_trip(tmp_path):
+    result = evaluate(tmp_path, "out[:4].copy_(x[:4] + 1); x.add_(1); return None")
+    payload = json.loads(json.dumps(_correctness_to_payload(result)))
+    restored = _correctness_from_payload(payload)
+    assert restored == result
+    assert any(not diff.passed for diff in restored.cases[0].mutated_inputs)
+    assert any(not diff.passed for diff in restored.cases[0].unexpected_mutations)
+
+
+@pytest.mark.parametrize("candidate", ["return None", "out[:4].copy_(x[:4] + 1); return None"])
+def test_missing_or_partial_mutation_fails(tmp_path, candidate):
+    result = evaluate(tmp_path, candidate)
+    assert result.status == "failed"
+    assert any(not diff.passed for diff in result.cases[0].mutated_inputs)
+
+
+@pytest.mark.parametrize("role", ["reference", "candidate"])
+def test_undeclared_write_detected_on_both_sides(tmp_path, role):
+    bodies = {
+        "reference": "out.copy_(x + 1); return None",
+        "candidate": "out.copy_(x + 1); return None",
+    }
+    bodies[role] = "out.copy_(x + 1); x.add_(1); return None"
+    result = evaluate(tmp_path, bodies["candidate"], reference=bodies["reference"])
+    assert result.status == "failed"
+    assert any(
+        not diff.passed and diff.name == f"{role}.input.x"
+        for diff in result.cases[0].unexpected_mutations
+    )
+
+
+def test_unknown_mutation_name_fails_before_invocation(tmp_path):
+    result = evaluate(tmp_path, "raise AssertionError('must not run')", mutations=("missing",))
+    assert result.status == "failed"
+    assert "Unknown mutated input names" in result.cases[0].error
+    assert "must not run" not in result.cases[0].error
+
+
+def test_clone_preserves_aliases_across_args_and_kwargs():
+    storage = torch.arange(32.0)
+    x, y = storage[3:15:2], storage[5:17:2]
+    original = ModelInputs((x,), {"nested": {"y": [y]}})
+    cloned = clone_model_inputs(original)
+    other = clone_model_inputs(original)
+    a, b = cloned.args[0], cloned.kwargs["nested"]["y"][0]
+    assert a.stride() == x.stride()
+    assert a.storage_offset() == 3
+    assert b.storage_offset() == 5
+    assert a.untyped_storage()._cdata == b.untyped_storage()._cdata
+    assert a.untyped_storage()._cdata != other.args[0].untyped_storage()._cdata
+    a[1] = 999
+    assert b[0].item() == 999
+    assert storage[5].item() == other.args[0][1].item() == 5
+
+
+def test_unchanged_check_includes_hidden_storage_tail_and_nan_bytes():
+    original = torch.tensor([float("nan"), 1.0, 2.0, 3.0])
+    copied = original.clone()
+    assert all(d.passed for d in _check_unchanged(original[:2], copied[:2], name="x"))
+    copied[3] = 9
+    assert not all(d.passed for d in _check_unchanged(original[:2], copied[:2], name="x"))
+
+
+@pytest.mark.parametrize(
+    "before,after",
+    [
+        ({"x": [None, 1]}, {"x": [None, 2]}),
+        ({"x": None}, {"y": None}),
+        ([None], [None, None]),
+        ((1,), [1]),
+        (None, 0),
+        (torch.arange(6.0).reshape(2, 3), torch.arange(6.0).reshape(3, 2)),
+        (torch.ones(2, 2), torch.ones(2, 2).T),
+        (torch.ones(2), torch.ones(2).double()),
+    ],
+)
+def test_unchanged_nested_and_metadata_mismatches(before, after):
+    assert not all(d.passed for d in _check_unchanged(before, after, name="input"))
+
+
+def test_unchanged_nested_values_pass():
+    value = {"x": [None, (True, 1, torch.arange(3.0))]}
+    cloned = clone_model_inputs(ModelInputs((value,), {})).args[0]
+    assert all(d.passed for d in _check_unchanged(value, cloned, name="input"))
+
+
+@pytest.mark.parametrize("strict", [False, True])
+@pytest.mark.parametrize(
+    "left,right",
+    [
+        (None, 0),
+        ({"x": None}, {"y": None}),
+        ([None], [None, None]),
+        ({"x": None}, [None]),
+        (torch.ones(2), torch.ones(3)),
+    ],
+)
+def test_value_tree_structure_mismatches(left, right, strict):
+    diffs = _compare_value_trees(left, right, name="out", atol=0, rtol=0, strict_types=strict)
+    assert not all(d.passed for d in diffs)
+    assert any(d.error for d in diffs)
+
+
+@pytest.mark.parametrize("strict", [False, True])
+def test_nested_none_leaves_pass(strict):
+    value = {"a": (None, [torch.ones(2), 1, True])}
+    diffs = _compare_value_trees(value, value, name="out", atol=0, rtol=0, strict_types=strict)
+    assert all(d.passed for d in diffs)
+    assert [d.name for d in diffs] == ["out.a[0]", "out.a[1][0]", "out.a[1][1]", "out.a[1][2]"]
+
+
+@pytest.mark.parametrize(
+    "reference,candidate",
+    [
+        ("return (x, out)", "return [x, out]"),
+        ("return True", "return 1"),
+        ("return x", "return x.double()"),
+        ("return {'a': (None, True)}", "return {'a': [None, 1]}"),
+    ],
+)
+@pytest.mark.parametrize("mutations", [None, ()])
+def test_legacy_compatibility_and_explicit_strict_contract(
+    tmp_path, reference, candidate, mutations
+):
+    result = evaluate(tmp_path, candidate, reference=reference, mutations=mutations)
+    assert result.status == ("passed" if mutations is None else "failed"), result.reason
+
+
+@pytest.mark.parametrize("mutations", [None, ()])
+def test_scalar_tolerance_is_retained(tmp_path, mutations):
+    result = evaluate(tmp_path, "return 1.001", reference="return 1.0", mutations=mutations)
+    assert result.status == "passed", result.reason
+
+
+@pytest.mark.parametrize("declare_alias", [False, True])
+def test_mutation_declaration_covers_shared_storage_aliases(tmp_path, declare_alias):
+    result = evaluate(
+        tmp_path,
+        "out.add_(1); return None",
+        reference="out.add_(1); return None",
+        mutations=("x", "out") if declare_alias else ("out",),
+        inputs="(lambda pool: [pool[:4], pool[4:]])(torch.arange(8.))",
+    )
+    assert result.status == ("passed" if declare_alias else "failed"), result.reason
+    if not declare_alias:
+        assert {d.name for d in result.cases[0].unexpected_mutations if not d.passed} == {
+            "reference.input.x",
+            "candidate.input.x",
+        }


### PR DESCRIPTION
## Summary
- Accept exact `None` returns without wrapping production operator ABIs.
- Compare declared mutable inputs via `benchmark_contract.mutates_inputs` and detect undeclared writes on both reference and candidate inputs.
- Preserve strided storage offsets and shared-storage aliases when cloning call trees.
- Scope strict return container/scalar types and tensor dtypes to benchmarks explicitly declaring `mutates_inputs` (including an empty list). Existing benchmarks retain legacy tuple/list, numeric scalar, dtype and floating-point tolerance comparison semantics.
- Serialize mutation diagnostics across correctness workers and use `dataclasses.replace` when renaming output diffs.

## Tests and validation
- Added 42 regression cases covering None leaves, nested structures, mutation/no-op/partial-write failures, hidden storage tails, reference/candidate undeclared writes, cross-argument aliases, legacy versus explicit strict contracts, scalar tolerances, and worker JSON round trips.
- Updated the existing overlapping-stride clone test to verify preserved aliasing without modifying the original input.
- Full repository suite on macOS arm64, Python 3.12.13 / PyTorch 2.14.0: **589 passed, 8 skipped**. All 8 skips require CUDA/HIP GPUs.
- Ruff checks for changed Python files and `git diff --check` passed.
- Reproduction after installing the project and dev dependencies: `python -m pytest -q -rs`.
- This revision does not claim a full GPU operator-corpus or performance validation run.

## Contract boundaries
- Undeclared-input checks compare entire backing storage, including tails. If one declared mutable argument shares storage with an undeclared argument, writes to even disjoint regions are flagged. Every affected supplied alias must be declared mutable, or independently stored if the ABI requires immutability.
- Declared mutable inputs are compared over their full logical views, not arbitrary bytes outside their union.
- CUDA Graph replay's separate output-only checker does not certify mutable state.
- Cross-device transfer and arbitrary sparse/nested input state are outside these strided-input checks.

No trace datasets, model data, deployment files, or internal submodule changes are included.
